### PR TITLE
⬆️ Bump to 5.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-msgs5 VERSION 5.1.0)
+project(ignition-msgs5 VERSION 5.2.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,22 @@
 
 ### Ignition Msgs 5.x.x
 
+### Ignition Msgs 5.2.0 (2020-05-14)
+
+1. Handle empty xml elements
+    * [BitBucket pull request 172](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-msgs/pull-requests/172)
+
+1. Ignore deprecation warnings on generated code
+    * [BitBucket pull request 170](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-msgs/pull-requests/170)
+
+1. Add SdfGeneratorConfig message containing configuration options for generating SDFormat from currently loaded worlds
+    * [BitBucket pull request 174](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-msgs/pull-requests/174)
+
+1. BitBucket to GitHub migration
+    * [Pull request](https://github.com/ignitionrobotics/ign-msgs/pull/39)
+    * [Pull request](https://github.com/ignitionrobotics/ign-msgs/pull/40)
+    * [Pull request](https://github.com/ignitionrobotics/ign-msgs/pull/43)
+
 ### Ignition Msgs 5.1.0
 
 1. Add ConvertPixelFormatType functions to Utility.hh


### PR DESCRIPTION
* BitBucket PRs:
    * https://bitbucket.org/ignitionrobotics/ign-msgs/branches/compare/ign-msgs4%0Dignition-msgs5_5.1.0#pull-requests
    * https://bitbucket.org/ignitionrobotics/ign-msgs/branches/compare/ign-msgs5%0Dignition-msgs5_5.1.0#pull-requests

* GitHub diff: https://github.com/ignitionrobotics/ign-msgs/compare/ignition-msgs5_5.1.0...ign-msgs5

* There's nothing to be forward-ported from `ign-msgs4`

* No open PRs targetting `ign-msgs5`