### PR TITLE
Add CMake options to support cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,22 @@ ign_configure_project()
 # Set project-specific options
 #============================================================================
 
+# Cross-compilation related options
+# In a cross-compilation scenario, it is possible that the ign_msgs_gen
+# generator compiled for the target machine cannot be used to generate
+# the C++ code corresponding to the .proto definition. For this scenario, 
+# the following two options can be used as follows. 
+# First of all, ign-msgs is compiled targeting the host machine, and in the
+# build targeting the host, the INSTALL_IGN_MSGS_GEN_EXECUTABLE option is
+# enabled:
+# > cmake -DINSTALL_IGN_MSGS_GEN_EXECUTABLE:BOOL=ON .. 
+# ensuring that the ign_msgs_gen is installed in 
+# <host_install_prefix>/bin/ign_msgs_gen . Then, the same version of ign-msgs 
+# can be cross-compiled, and in the cross-compilation build the location of the
+# host ign_msgs_gen is specified via the IGN_MSGS_GEN_EXECUTABLE 
+# CMake cache variable: 
+# > cmake -IGN_MSGS_GEN_EXECUTABLE=<host_install_prefix>/bin/ign_msgs_gen .. 
+
 option(
   INSTALL_IGN_MSGS_GEN_EXECUTABLE
   "Install the ign_msgs_gen executable."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,18 @@ ign_configure_project()
 # Set project-specific options
 #============================================================================
 
-# ignition-msgs currently has no options that are unique to it
+option(
+  INSTALL_IGN_MSGS_GEN_EXECUTABLE
+  "Install the ign_msgs_gen executable."
+  OFF)
+mark_as_advanced(INSTALL_IGN_MSGS_GEN_EXECUTABLE)
+
+set(
+  IGN_MSGS_GEN_EXECUTABLE
+  "$<TARGET_FILE:ign_msgs_gen>"
+  CACHE STRING
+  "ign_msgs_gen executable used in the ign_msgs_protoc CMake function.")
+mark_as_advanced(IGN_MSGS_GEN_EXECUTABLE)
 
 #============================================================================
 # Search for project-specific dependencies

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,10 @@ if (UNIX)
   target_link_libraries(ign_msgs_gen pthread)
 endif()
 
+if(INSTALL_IGN_MSGS_GEN_EXECUTABLE)
+  set_target_properties(ign_msgs_gen PROPERTIES VERSION ${PROJECT_VERSION_FULL})
+  install(TARGETS ign_msgs_gen DESTINATION ${IGN_BIN_INSTALL_DIR})
+endif()
 
 ##################################################
 # A function that calls protoc on a protobuf file
@@ -57,7 +61,7 @@ function(ign_msgs_protoc)
     list(APPEND ${ign_msgs_protoc_OUTPUT_CPP_CC_VAR} ${output_source})
     list(APPEND output_files ${output_header})
     list(APPEND output_files ${output_source})
-    list(APPEND protoc_args "--plugin=protoc-gen-ignmsgs=$<TARGET_FILE:ign_msgs_gen>")
+    list(APPEND protoc_args "--plugin=protoc-gen-ignmsgs=${IGN_MSGS_GEN_EXECUTABLE}")
     list(APPEND protoc_args "--cpp_out=dllexport_decl=IGNITION_MSGS_VISIBLE:${ign_msgs_protoc_OUTPUT_CPP_DIR}")
     list(APPEND protoc_args "--ignmsgs_out" "${ign_msgs_protoc_OUTPUT_CPP_DIR}")
     set(${ign_msgs_protoc_OUTPUT_CPP_HH_VAR} ${${ign_msgs_protoc_OUTPUT_CPP_HH_VAR}} PARENT_SCOPE)


### PR DESCRIPTION
This commit adds two CMake options:
* `INSTALL_IGN_MSGS_GEN_EXECUTABLE` if this option is enabled, the ign_msgs_gen protobuf executable plugin is also installed, so that this option can be enabled in host builds to permit cross-compilation builds to use it to generate the messages. As this executable is not side by side installable with other ignition-msgs installations with different major versions and this is an advanced option meant just for packaging, by default it is set to OFF.
* `IGN_MSGS_GEN_EXECUTABLE`: this string variable can be set to have ign-msgs use a ign_msgs_gen executable plugin that was not build by the project, to enable cross-compilation scenarios.

Fix https://github.com/ignitionrobotics/ign-msgs/issues/34 .