### PR TITLE
Feature/add visual arrow and axis

### DIFF
--- a/proto/ignition/msgs/geometry.proto
+++ b/proto/ignition/msgs/geometry.proto
@@ -52,6 +52,8 @@ message Geometry
     POLYLINE     = 9;
     CONE         = 10;
     EMPTY        = 11;
+    ARROW        = 12;
+    AXIS         = 13;
   }
 
   /// \brief Optional header data

--- a/proto/ignition/msgs/marker.proto
+++ b/proto/ignition/msgs/marker.proto
@@ -47,6 +47,8 @@ message Marker
     TRIANGLE_LIST  = 9;
     TRIANGLE_STRIP = 10;
     CONE           = 11;
+    ARROW          = 12;
+    AXIS           = 13;
   }
 
   /// \brief Visilibity defines what cameras render the marker.


### PR DESCRIPTION
This PR builds on PR #61. 

It adds additional types ARROW and AXIS to both geometry type message and marker type message. This is to allow for the creation of visual arrow and axis scene types with either a visual message or marker message. I assumed only the type is required because position and scale is provided by the visual and maker messages.