### PR TITLE
Support multiple messages in a proto file

### DIFF
--- a/include/ignition/msgs/Factory.hh
+++ b/include/ignition/msgs/Factory.hh
@@ -128,7 +128,7 @@ namespace ignition
         ignition::msgs::Factory::Register(_msgtype, New##_classname);\
       } \
     }; \
-    static IgnMsg##_classname IgnitionMessagesInitializer;
+    static IgnMsg##_classname IgnitionMessagesInitializer##_classname;
     }
   }
 }

--- a/src/Factory_TEST.cc
+++ b/src/Factory_TEST.cc
@@ -78,3 +78,71 @@ TEST(FactoryTest, NewDynamicFactory)
   msg = msgs::Factory::New("example.msgs.StringMsg");
   EXPECT_TRUE(msg.get() != nullptr);
 }
+
+/////////////////////////////////////////////////
+TEST(FactoryTest, NewAllRegisteredTypes)
+{
+  std::vector<std::string> types;
+  msgs::Factory::Types(types);
+  EXPECT_FALSE(types.empty());
+
+  for (const auto &type : types)
+  {
+    auto msg = msgs::Factory::New(type);
+    ASSERT_NE(nullptr, msg.get()) << type;
+  }
+}
+
+/////////////////////////////////////////////////
+TEST(FactoryTest, MultipleMessagesInAProto)
+{
+  auto typesInSameFile =
+  {
+    "ign_msgs.SerializedEntityMap",
+    "ign_msgs.SerializedStateMap",
+    "ign_msgs.SerializedStepMap"
+  };
+
+  std::vector<std::string> types;
+  msgs::Factory::Types(types);
+  EXPECT_FALSE(types.empty());
+
+  for (auto type : typesInSameFile)
+  {
+    // Check all types are registered
+    EXPECT_NE(std::find(types.begin(), types.end(), std::string(type)),
+        types.end()) << type;
+
+    // Check all types can be newed
+    auto msg = msgs::Factory::New(type);
+    EXPECT_NE(nullptr, msg.get()) << type;
+  }
+
+  // Compile-time check that pointer types exist
+  {
+    msgs::SerializedEntityMapUniquePtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
+    msgs::SerializedEntityMapSharedPtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+
+  {
+    msgs::SerializedStateMapUniquePtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
+    msgs::SerializedStateMapSharedPtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+
+  {
+    msgs::SerializedStepMapUniquePtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
+    msgs::SerializedStepMapSharedPtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+}

--- a/src/Factory_TEST.cc
+++ b/src/Factory_TEST.cc
@@ -124,7 +124,15 @@ TEST(FactoryTest, MultipleMessagesInAProto)
     EXPECT_EQ(nullptr, ptr);
   }
   {
+    msgs::ConstSerializedEntityMapUniquePtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
     msgs::SerializedEntityMapSharedPtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
+    msgs::ConstSerializedEntityMapSharedPtr ptr{nullptr};
     EXPECT_EQ(nullptr, ptr);
   }
 
@@ -133,7 +141,15 @@ TEST(FactoryTest, MultipleMessagesInAProto)
     EXPECT_EQ(nullptr, ptr);
   }
   {
+    msgs::ConstSerializedStateMapUniquePtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
     msgs::SerializedStateMapSharedPtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
+    msgs::ConstSerializedStateMapSharedPtr ptr{nullptr};
     EXPECT_EQ(nullptr, ptr);
   }
 
@@ -142,7 +158,15 @@ TEST(FactoryTest, MultipleMessagesInAProto)
     EXPECT_EQ(nullptr, ptr);
   }
   {
+    msgs::ConstSerializedStepMapUniquePtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
     msgs::SerializedStepMapSharedPtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
+    msgs::ConstSerializedStepMapSharedPtr ptr{nullptr};
     EXPECT_EQ(nullptr, ptr);
   }
 }

--- a/src/Generator.cc
+++ b/src/Generator.cc
@@ -141,11 +141,14 @@ bool Generator::Generate(const FileDescriptor *_file,
     printer.Print(" 4127 4068)\n", "name", "includes");
     printer.Print("#endif\n", "name", "includes");
 
-    // Call the IGN_REGISTER_STATIC_MSG macro
-    std::string factory = "IGN_REGISTER_STATIC_MSG(\"ign_msgs.";
-    factory += _file->message_type(0)->name() + "\", " +
-      _file->message_type(0)->name() +")";
-    printer.Print(factory.c_str(), "name", "includes");
+    // Call the IGN_REGISTER_STATIC_MSG macro for each message
+    for (auto i = 0; i < _file->message_type_count(); ++i)
+    {
+      std::string factory = "IGN_REGISTER_STATIC_MSG(\"ign_msgs.";
+      factory += _file->message_type(i)->name() + "\", " +
+        _file->message_type(i)->name() +")\n";
+      printer.Print(factory.c_str(), "name", "includes");
+    }
   }
 
   // Inject code in the auto-generated header files immediately before closing
@@ -155,27 +158,30 @@ bool Generator::Generate(const FileDescriptor *_file,
         _generatorContext->OpenForInsert(headerFilename, "namespace_scope"));
     io::Printer printer(output.get(), '$');
 
-    // Define std::unique_ptr types for our messages
-    std::string ptrTypes = "typedef std::unique_ptr<"
-      + _file->message_type(0)->name() + "> "
-      + _file->message_type(0)->name() + "UniquePtr;\n";
+    for (auto i = 0; i < _file->message_type_count(); ++i)
+    {
+      // Define std::unique_ptr types for our messages
+      std::string ptrTypes = "typedef std::unique_ptr<"
+        + _file->message_type(i)->name() + "> "
+        + _file->message_type(i)->name() + "UniquePtr;\n";
 
-    // Define const std::unique_ptr types for our messages
-    ptrTypes += "typedef std::unique_ptr<const "
-      + _file->message_type(0)->name() + "> Const"
-      + _file->message_type(0)->name() + "UniquePtr;\n";
+      // Define const std::unique_ptr types for our messages
+      ptrTypes += "typedef std::unique_ptr<const "
+        + _file->message_type(i)->name() + "> Const"
+        + _file->message_type(i)->name() + "UniquePtr;\n";
 
-    // Define std::shared_ptr types for our messages
-    ptrTypes += "typedef std::shared_ptr<"
-      + _file->message_type(0)->name() + "> "
-      + _file->message_type(0)->name() + "SharedPtr;\n";
+      // Define std::shared_ptr types for our messages
+      ptrTypes += "typedef std::shared_ptr<"
+        + _file->message_type(i)->name() + "> "
+        + _file->message_type(i)->name() + "SharedPtr;\n";
 
-    // Define const std::shared_ptr types for our messages
-    ptrTypes += "typedef std::shared_ptr<const "
-      + _file->message_type(0)->name() + "> Const"
-      + _file->message_type(0)->name() + "SharedPtr;\n";
+      // Define const std::shared_ptr types for our messages
+      ptrTypes += "typedef std::shared_ptr<const "
+        + _file->message_type(i)->name() + "> Const"
+        + _file->message_type(i)->name() + "SharedPtr;\n";
 
-    printer.Print(ptrTypes.c_str(), "name", "namespace_scope");
+      printer.Print(ptrTypes.c_str(), "name", "namespace_scope");
+    }
   }
 
   // Pop the warning suppression stack for MSVC


### PR DESCRIPTION
Fixes #69 

We have a few proto files that define more than one message. These messages have been working with Ignition Transport, but they didn't work with the factory. This PR updates the generator so that all messages in a file are registered with the factory. It also adds the special pointer types for them.

I'm targeting this at `master` (future Dome branch), because I believe that the change in the name of the static object created in the macro will break ABI. This is unfortunate, but I'm not sure how to work around that.