### PR TITLE
Added utility functions to convert between msg::time and std::chrono time_point

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,18 +23,18 @@ ign_configure_project(VERSION_SUFFIX pre1)
 # Cross-compilation related options
 # In a cross-compilation scenario, it is possible that the ign_msgs_gen
 # generator compiled for the target machine cannot be used to generate
-# the C++ code corresponding to the .proto definition. For this scenario, 
-# the following two options can be used as follows. 
+# the C++ code corresponding to the .proto definition. For this scenario,
+# the following two options can be used as follows.
 # First of all, ign-msgs is compiled targeting the host machine, and in the
 # build targeting the host, the INSTALL_IGN_MSGS_GEN_EXECUTABLE option is
 # enabled:
-# > cmake -DINSTALL_IGN_MSGS_GEN_EXECUTABLE:BOOL=ON .. 
-# ensuring that the ign_msgs_gen is installed in 
-# <host_install_prefix>/bin/ign_msgs_gen . Then, the same version of ign-msgs 
+# > cmake -DINSTALL_IGN_MSGS_GEN_EXECUTABLE:BOOL=ON ..
+# ensuring that the ign_msgs_gen is installed in
+# <host_install_prefix>/bin/ign_msgs_gen . Then, the same version of ign-msgs
 # can be cross-compiled, and in the cross-compilation build the location of the
-# host ign_msgs_gen is specified via the IGN_MSGS_GEN_EXECUTABLE 
-# CMake cache variable: 
-# > cmake -IGN_MSGS_GEN_EXECUTABLE=<host_install_prefix>/bin/ign_msgs_gen .. 
+# host ign_msgs_gen is specified via the IGN_MSGS_GEN_EXECUTABLE
+# CMake cache variable:
+# > cmake -IGN_MSGS_GEN_EXECUTABLE=<host_install_prefix>/bin/ign_msgs_gen ..
 
 option(
   INSTALL_IGN_MSGS_GEN_EXECUTABLE
@@ -65,7 +65,7 @@ ign_find_package(IgnProtobuf
 
 #--------------------------------------
 # Find ignition-math
-ign_find_package(ignition-math6 REQUIRED)
+ign_find_package(ignition-math6 REQUIRED VERSION 6.5)
 set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
 
 #--------------------------------------

--- a/include/ignition/msgs/Utility.hh
+++ b/include/ignition/msgs/Utility.hh
@@ -250,10 +250,12 @@ namespace ignition
     msgs::Float Convert(const float &_f);
 
     /// \brief Convert a std::chrono::system_clock::time_point to a msgs::Time
-    /// \param[in] _time_point The std::chrono::system_clock::time_poin to convert
+    /// \param[in] _time_point The std::chrono::system_clock::time_poin to
+    /// convert
     /// \return A msgs::Time object
     IGNITION_MSGS_VISIBLE
-    msgs::Time Convert(const std::chrono::system_clock::time_point &_time_point);
+    msgs::Time Convert(
+      const std::chrono::system_clock::time_point &_time_point);
 
     /// \brief Convert a string to a msgs::Joint::Type enum.
     /// \param[in] _str Joint type string.

--- a/include/ignition/msgs/Utility.hh
+++ b/include/ignition/msgs/Utility.hh
@@ -147,6 +147,12 @@ namespace ignition
     IGNITION_MSGS_VISIBLE
     float Convert(const msgs::Float &_m);
 
+    /// \brief Convert a msgs::Time to a std::chrono::system_clock::time_point
+    /// \param[in] _time The message to convert
+    /// \return A std::chrono::system_clock::time_point object
+    IGNITION_MSGS_VISIBLE
+    std::chrono::system_clock::time_point Convert(const msgs::Time &_time);
+
     /// \brief Convert a ignition::math::Vector3d to a msgs::Vector3d
     /// \param[in] _v The vector to convert
     /// \return A msgs::Vector3d object
@@ -242,6 +248,12 @@ namespace ignition
     /// \return A msgs::Float object
     IGNITION_MSGS_VISIBLE
     msgs::Float Convert(const float &_f);
+
+    /// \brief Convert a std::chrono::system_clock::time_point to a msgs::Time
+    /// \param[in] _time_point The std::chrono::system_clock::time_poin to convert
+    /// \return A msgs::Time object
+    IGNITION_MSGS_VISIBLE
+    msgs::Time Convert(const std::chrono::system_clock::time_point &_time_point);
 
     /// \brief Convert a string to a msgs::Joint::Type enum.
     /// \param[in] _str Joint type string.

--- a/include/ignition/msgs/Utility.hh
+++ b/include/ignition/msgs/Utility.hh
@@ -147,11 +147,11 @@ namespace ignition
     IGNITION_MSGS_VISIBLE
     float Convert(const msgs::Float &_m);
 
-    /// \brief Convert a msgs::Time to a std::chrono::system_clock::time_point
+    /// \brief Convert a msgs::Time to a std::chrono::steady_clock::time_point
     /// \param[in] _time The message to convert
-    /// \return A std::chrono::system_clock::time_point object
+    /// \return A std::chrono::steady_clock::time_point object
     IGNITION_MSGS_VISIBLE
-    std::chrono::system_clock::time_point Convert(const msgs::Time &_time);
+    std::chrono::steady_clock::time_point Convert(const msgs::Time &_time);
 
     /// \brief Convert a ignition::math::Vector3d to a msgs::Vector3d
     /// \param[in] _v The vector to convert
@@ -249,13 +249,13 @@ namespace ignition
     IGNITION_MSGS_VISIBLE
     msgs::Float Convert(const float &_f);
 
-    /// \brief Convert a std::chrono::system_clock::time_point to a msgs::Time
+    /// \brief Convert a std::chrono::steady_clock::time_point to a msgs::Time
     /// \param[in] _time_point The std::chrono::system_clock::time_poin to
     /// convert
     /// \return A msgs::Time object
     IGNITION_MSGS_VISIBLE
     msgs::Time Convert(
-      const std::chrono::system_clock::time_point &_time_point);
+      const std::chrono::steady_clock::time_point &_time_point);
 
     /// \brief Convert a string to a msgs::Joint::Type enum.
     /// \param[in] _str Joint type string.

--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -206,7 +206,7 @@ namespace ignition
     }
 
     /////////////////////////////////////////////////
-    std::chrono::system_clock::time_point Convert(const msgs::Time &_time)
+    std::chrono::steady_clock::time_point Convert(const msgs::Time &_time)
     {
       return math::secNsecToTimePoint(_time.sec(), _time.nsec());;
     }
@@ -346,7 +346,7 @@ namespace ignition
     }
 
     /////////////////////////////////////////////////
-    msgs::Time Convert(const std::chrono::system_clock::time_point &_time_point)
+    msgs::Time Convert(const std::chrono::steady_clock::time_point &_time_point)
     {
       std::pair<uint64_t, uint64_t> timeSecAndNsecs =
         ignition::math::timePointToSecNsec(_time_point);

--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -346,10 +346,10 @@ namespace ignition
     }
 
     /////////////////////////////////////////////////
-    msgs::Time Convert(const std::chrono::steady_clock::time_point &_time_point)
+    msgs::Time Convert(const std::chrono::steady_clock::time_point &_timePoint)
     {
       std::pair<uint64_t, uint64_t> timeSecAndNsecs =
-        ignition::math::timePointToSecNsec(_time_point);
+        ignition::math::timePointToSecNsec(_timePoint);
       msgs::Time msg;
       msg.set_sec(timeSecAndNsecs.first);
       msg.set_nsec(timeSecAndNsecs.second);

--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -206,6 +206,16 @@ namespace ignition
     }
 
     /////////////////////////////////////////////////
+    std::chrono::system_clock::time_point Convert(const msgs::Time &_time)
+    {
+      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(_time.sec() + _time.nsec()/1e9));
+      std::chrono::system_clock::time_point result = std::chrono::system_clock::from_time_t(0);
+      result += duration;
+      return result;
+    }
+
+    /////////////////////////////////////////////////
     msgs::Vector3d Convert(const ignition::math::Vector3d &_v)
     {
       msgs::Vector3d result;
@@ -337,6 +347,17 @@ namespace ignition
       msgs::Double result;
       result.set_data(_d);
       return result;
+    }
+
+    /////////////////////////////////////////////////
+    msgs::Time Convert(const std::chrono::system_clock::time_point &_time_point)
+    {
+      std::pair<uint64_t, uint64_t> timeSecAndNsecs =
+        ignition::math::timePointToSecNsec(_time_point);
+      msgs::Time msg;
+      msg.set_sec(timeSecAndNsecs.first);
+      msg.set_nsec(timeSecAndNsecs.second);
+      return msg;
     }
 
     /////////////////////////////////////////////

--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -208,11 +208,7 @@ namespace ignition
     /////////////////////////////////////////////////
     std::chrono::system_clock::time_point Convert(const msgs::Time &_time)
     {
-      auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        std::chrono::duration<double>(_time.sec() + _time.nsec()/1e9));
-      std::chrono::system_clock::time_point result = std::chrono::system_clock::from_time_t(0);
-      result += duration;
-      return result;
+      return math::secNsecToTimePoint(_time.sec(), _time.nsec());;
     }
 
     /////////////////////////////////////////////////

--- a/src/Utility_TEST.cc
+++ b/src/Utility_TEST.cc
@@ -317,6 +317,23 @@ TEST(UtilityTest, ConvertFloat)
 }
 
 /////////////////////////////////////////////////
+TEST(UtilityTest, ConvertTimePoint)
+{
+  std::chrono::system_clock::time_point time_point = math::secNsecToTimePoint(0, 0);
+  msgs::Time msg = msgs::Convert(time_point);
+  EXPECT_EQ(0, msg.sec());
+  EXPECT_EQ(0, msg.nsec());
+
+  std::chrono::system_clock::time_point s = msgs::Convert(msg);
+  EXPECT_EQ(s, std::chrono::system_clock::from_time_t(0));
+
+  time_point = math::secNsecToTimePoint(200, 999);
+  msg = msgs::Convert(time_point);
+  EXPECT_EQ(200, msg.sec());
+  EXPECT_EQ(999, msg.nsec());
+}
+
+/////////////////////////////////////////////////
 TEST(UtilityTest, SetVector3)
 {
   msgs::Vector3d msg;

--- a/src/Utility_TEST.cc
+++ b/src/Utility_TEST.cc
@@ -319,17 +319,17 @@ TEST(UtilityTest, ConvertFloat)
 /////////////////////////////////////////////////
 TEST(UtilityTest, ConvertTimePoint)
 {
-  std::chrono::steady_clock::time_point time_point =
+  std::chrono::steady_clock::time_point timePoint =
     math::secNsecToTimePoint(0, 0);
-  msgs::Time msg = msgs::Convert(time_point);
+  msgs::Time msg = msgs::Convert(timePoint);
   EXPECT_EQ(0, msg.sec());
   EXPECT_EQ(0, msg.nsec());
 
   std::chrono::steady_clock::time_point s = msgs::Convert(msg);
   EXPECT_EQ(s, math::secNsecToTimePoint(0, 0));
 
-  time_point = math::secNsecToTimePoint(200, 999);
-  msg = msgs::Convert(time_point);
+  timePoint = math::secNsecToTimePoint(200, 999);
+  msg = msgs::Convert(timePoint);
   EXPECT_EQ(200, msg.sec());
   EXPECT_EQ(999, msg.nsec());
 }

--- a/src/Utility_TEST.cc
+++ b/src/Utility_TEST.cc
@@ -319,7 +319,8 @@ TEST(UtilityTest, ConvertFloat)
 /////////////////////////////////////////////////
 TEST(UtilityTest, ConvertTimePoint)
 {
-  std::chrono::system_clock::time_point time_point = math::secNsecToTimePoint(0, 0);
+  std::chrono::system_clock::time_point time_point =
+    math::secNsecToTimePoint(0, 0);
   msgs::Time msg = msgs::Convert(time_point);
   EXPECT_EQ(0, msg.sec());
   EXPECT_EQ(0, msg.nsec());

--- a/src/Utility_TEST.cc
+++ b/src/Utility_TEST.cc
@@ -319,14 +319,14 @@ TEST(UtilityTest, ConvertFloat)
 /////////////////////////////////////////////////
 TEST(UtilityTest, ConvertTimePoint)
 {
-  std::chrono::system_clock::time_point time_point =
+  std::chrono::steady_clock::time_point time_point =
     math::secNsecToTimePoint(0, 0);
   msgs::Time msg = msgs::Convert(time_point);
   EXPECT_EQ(0, msg.sec());
   EXPECT_EQ(0, msg.nsec());
 
-  std::chrono::system_clock::time_point s = msgs::Convert(msg);
-  EXPECT_EQ(s, std::chrono::system_clock::from_time_t(0));
+  std::chrono::steady_clock::time_point s = msgs::Convert(msg);
+  EXPECT_EQ(s, math::secNsecToTimePoint(0, 0));
 
   time_point = math::secNsecToTimePoint(200, 999);
   msg = msgs::Convert(time_point);


### PR DESCRIPTION
This PR is related with this issue https://github.com/ignitionrobotics/ign-common/issues/61. The idea it's to deprecate the class `common::Time` in favor of `std::chrono`.

Related with 
 - https://github.com/ignitionrobotics/ign-common/pull/90
 - https://github.com/ignitionrobotics/ign-sensors/pull/41
 - https://github.com/ignitionrobotics/ign-common/pull/90
 - https://github.com/ignitionrobotics/ign-math/pull/150

Added helpers functions to convert between
 - msg::Time to time_point
 - time_point to msg::Time
 - some tests too

Signed-off-by: ahcorde <ahcorde@gmail.com>