### PR TITLE
Convert functions between duration and ignition::time

### DIFF
--- a/include/ignition/msgs/Utility.hh
+++ b/include/ignition/msgs/Utility.hh
@@ -147,11 +147,11 @@ namespace ignition
     IGNITION_MSGS_VISIBLE
     float Convert(const msgs::Float &_m);
 
-    /// \brief Convert a msgs::Time to a std::chrono::steady_clock::time_point
+    /// \brief Convert a msgs::Time to a std::chrono::steady_clock::duration
     /// \param[in] _time The message to convert
-    /// \return A std::chrono::steady_clock::time_point object
+    /// \return A std::chrono::steady_clock::duration object
     IGNITION_MSGS_VISIBLE
-    std::chrono::steady_clock::time_point Convert(const msgs::Time &_time);
+    std::chrono::steady_clock::duration Convert(const msgs::Time &_time);
 
     /// \brief Convert a ignition::math::Vector3d to a msgs::Vector3d
     /// \param[in] _v The vector to convert
@@ -249,13 +249,13 @@ namespace ignition
     IGNITION_MSGS_VISIBLE
     msgs::Float Convert(const float &_f);
 
-    /// \brief Convert a std::chrono::steady_clock::time_point to a msgs::Time
-    /// \param[in] _time_point The std::chrono::system_clock::time_poin to
+    /// \brief Convert a std::chrono::steady_clock::duration to a msgs::Time
+    /// \param[in] _time_point The std::chrono::system_clock::duration to
     /// convert
     /// \return A msgs::Time object
     IGNITION_MSGS_VISIBLE
     msgs::Time Convert(
-      const std::chrono::steady_clock::time_point &_time_point);
+      const std::chrono::steady_clock::duration &_time_point);
 
     /// \brief Convert a string to a msgs::Joint::Type enum.
     /// \param[in] _str Joint type string.

--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -206,9 +206,10 @@ namespace ignition
     }
 
     /////////////////////////////////////////////////
-    std::chrono::steady_clock::time_point Convert(const msgs::Time &_time)
+    std::chrono::steady_clock::duration Convert(const msgs::Time &_time)
     {
-      return math::secNsecToTimePoint(_time.sec(), _time.nsec());;
+      return std::chrono::seconds(_time.sec()) +
+        std::chrono::nanoseconds(_time.nsec());
     }
 
     /////////////////////////////////////////////////
@@ -346,10 +347,10 @@ namespace ignition
     }
 
     /////////////////////////////////////////////////
-    msgs::Time Convert(const std::chrono::steady_clock::time_point &_timePoint)
+    msgs::Time Convert(const std::chrono::steady_clock::duration &_time_point)
     {
       std::pair<uint64_t, uint64_t> timeSecAndNsecs =
-        ignition::math::timePointToSecNsec(_timePoint);
+        ignition::math::durationToSecNsec(_time_point);
       msgs::Time msg;
       msg.set_sec(timeSecAndNsecs.first);
       msg.set_nsec(timeSecAndNsecs.second);

--- a/src/Utility_TEST.cc
+++ b/src/Utility_TEST.cc
@@ -319,17 +319,17 @@ TEST(UtilityTest, ConvertFloat)
 /////////////////////////////////////////////////
 TEST(UtilityTest, ConvertTimePoint)
 {
-  std::chrono::steady_clock::time_point timePoint =
-    math::secNsecToTimePoint(0, 0);
-  msgs::Time msg = msgs::Convert(timePoint);
+  std::chrono::steady_clock::duration time_point =
+    std::chrono::steady_clock::duration::zero();
+  msgs::Time msg = msgs::Convert(time_point);
   EXPECT_EQ(0, msg.sec());
   EXPECT_EQ(0, msg.nsec());
 
-  std::chrono::steady_clock::time_point s = msgs::Convert(msg);
-  EXPECT_EQ(s, math::secNsecToTimePoint(0, 0));
+  std::chrono::steady_clock::duration s = msgs::Convert(msg);
+  EXPECT_EQ(s, std::chrono::steady_clock::duration::zero());
 
-  timePoint = math::secNsecToTimePoint(200, 999);
-  msg = msgs::Convert(timePoint);
+  time_point = std::chrono::seconds(200) + std::chrono::nanoseconds(999);
+  msg = msgs::Convert(time_point);
   EXPECT_EQ(200, msg.sec());
   EXPECT_EQ(999, msg.nsec());
 }

--- a/src/Utility_TEST.cc
+++ b/src/Utility_TEST.cc
@@ -319,17 +319,17 @@ TEST(UtilityTest, ConvertFloat)
 /////////////////////////////////////////////////
 TEST(UtilityTest, ConvertTimePoint)
 {
-  std::chrono::steady_clock::duration time_point =
+  std::chrono::steady_clock::duration timePoint =
     std::chrono::steady_clock::duration::zero();
-  msgs::Time msg = msgs::Convert(time_point);
+  msgs::Time msg = msgs::Convert(timePoint);
   EXPECT_EQ(0, msg.sec());
   EXPECT_EQ(0, msg.nsec());
 
   std::chrono::steady_clock::duration s = msgs::Convert(msg);
   EXPECT_EQ(s, std::chrono::steady_clock::duration::zero());
 
-  time_point = std::chrono::seconds(200) + std::chrono::nanoseconds(999);
-  msg = msgs::Convert(time_point);
+  timePoint = std::chrono::seconds(200) + std::chrono::nanoseconds(999);
+  msg = msgs::Convert(timePoint);
   EXPECT_EQ(200, msg.sec());
   EXPECT_EQ(999, msg.nsec());
 }


### PR DESCRIPTION
As discussed in the PR https://github.com/ignitionrobotics/ign-sensors/pull/41#discussion_r485261003 makes sense to use `duration` instead of `time_point`, This function will convert secs and nanoseconds to `std::chrono::steady_clock::duration`

This PR is part of this issue https://github.com/ignitionrobotics/ign-common/issues/61.

Signed-off-by: ahcorde <ahcorde@gmail.com>