### PR TITLE
Add dependency conversion for model.config's

### DIFF
--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -976,7 +976,6 @@ namespace ignition
     bool ConvertFuelMetadata(const std::string &_modelConfigStr,
                              msgs::FuelMetadata &_meta)
     {
-      std::cout << "Converting string" << std::endl;
       ignition::msgs::FuelMetadata meta;
 
       // Load the model config into tinyxml

--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -1020,7 +1020,6 @@ namespace ignition
           auto uriElem = modelElem->FirstChildElement("uri");
           if (uriElem)
           {
-            std::string modelStr = uriElem->GetText();
             auto dependency = meta.add_dependencies();
             dependency->set_uri(uriElem->GetText());
           }
@@ -1130,6 +1129,16 @@ namespace ignition
         << "      <name>" << _meta.authors(i).name() << "</name>\n"
         << "      <email>" << _meta.authors(i).email() << "</email>\n"
         << "    </author>\n";
+      }
+
+      // Output dependency information.
+      for (int i = 0; i < _meta.dependencies_size(); ++i)
+      {
+        out << "    <depend>\n"
+        << "      <model>"
+        << "        <uri>" << _meta.dependencies(i).uri() << "</uri>\n"
+        << "      </model>"
+        << "    </depend>\n";
       }
 
       // Output closing tag.

--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -976,6 +976,7 @@ namespace ignition
     bool ConvertFuelMetadata(const std::string &_modelConfigStr,
                              msgs::FuelMetadata &_meta)
     {
+      std::cout << "Converting string" << std::endl;
       ignition::msgs::FuelMetadata meta;
 
       // Load the model config into tinyxml
@@ -1009,6 +1010,24 @@ namespace ignition
       elem = modelElement->FirstChildElement("description");
       if (elem && elem->GetText())
         meta.set_description(trimmed(elem->GetText()));
+
+      // Read the dependencies, if any.
+      elem = modelElement->FirstChildElement("depend");
+      while (elem)
+      {
+        auto modelElem = elem->FirstChildElement("model");
+        if (modelElem)
+        {
+          auto uriElem = modelElem->FirstChildElement("uri");
+          if (uriElem)
+          {
+            std::string modelStr = uriElem->GetText();
+            auto dependency = meta.add_dependencies();
+            dependency->set_uri(uriElem->GetText());
+          }
+        }
+        elem = elem->NextSiblingElement("depend");
+      }
 
       // Read the authors, if any.
       elem = modelElement->FirstChildElement("author");


### PR DESCRIPTION
Adds a conversion to get all of the dependencies from a `model.config`, not sure if it's desired since we're transitioning towards `metadata.pbtxt`, but since some `model.config`'s already have dependencies listed in the `depend` tag and for the sake of testing, I decided to make this PR, we can cancel it if it is not desired.