### PR TITLE
Add JointTrajectory message

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Ubuntu CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   bionic-ci:
@@ -23,5 +23,3 @@ jobs:
       - name: Compile and test
         id: ci
         uses: ignition-tooling/action-ignition-ci@focal
-        with:
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr-collection-labeler.yml
+++ b/.github/workflows/pr-collection-labeler.yml
@@ -1,6 +1,6 @@
 name: PR Collection Labeler
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   pr_collection_labeler:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 name: Ticket opened
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-msgs6 VERSION 6.0.0)
+project(ignition-msgs6 VERSION 6.1.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 ### Ignition Msgs 6.x.x
 
+### Ignition Msgs 6.1.0 (2020-12-01)
+
+1. Includes changes found in version 5.4.0.
+
 ### Ignition Msgs 6.0.0 (2020-09-28)
 
 1. Convert functions between duration and ignition::time.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Test coverage:
 
 Install required dependencies as follows:
 
-    sudo apt-get install libprotobuf-dev protobuf-compiler libprotoc-dev libignition-math4-dev
+    sudo apt-get install libprotobuf-dev protobuf-compiler libprotoc-dev libignition-math6-dev
 
 ## Installation
 
@@ -114,8 +114,8 @@ line is using symbolic links to each library's YAML file.
 mkdir ~/.ignition/tools/configs -p
 cd ~/.ignition/tools/configs/
 ln -s /usr/local/share/ignition/fuel4.yaml .
-ln -s /usr/local/share/ignition/transport7.yaml .
-ln -s /usr/local/share/ignition/transportlog7.yaml .
+ln -s /usr/local/share/ignition/transport8.yaml .
+ln -s /usr/local/share/ignition/transportlog8.yaml .
 ...
 export IGN_CONFIG_PATH=$HOME/.ignition/tools/configs
 ```

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ line is using symbolic links to each library's YAML file.
 ```
 mkdir ~/.ignition/tools/configs -p
 cd ~/.ignition/tools/configs/
-ln -s /usr/local/share/ignition/fuel4.yaml .
-ln -s /usr/local/share/ignition/transport8.yaml .
-ln -s /usr/local/share/ignition/transportlog8.yaml .
+ln -s /usr/local/share/ignition/fuel5.yaml .
+ln -s /usr/local/share/ignition/transport9.yaml .
+ln -s /usr/local/share/ignition/transportlog9.yaml .
 ...
 export IGN_CONFIG_PATH=$HOME/.ignition/tools/configs
 ```

--- a/proto/ignition/msgs/joint_trajectory.proto
+++ b/proto/ignition/msgs/joint_trajectory.proto
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+option java_outer_classname = "JointTrajectoryProtos";
+
+/// \ingroup ignition.msgs
+/// \interface JointTrajectory
+/// \brief Message for joint trajectory, used by JointTrajectoryController plugin
+
+import "ignition/msgs/header.proto";
+import "ignition/msgs/joint_trajectory_point.proto";
+
+message JointTrajectory
+{
+  /// \brief Optional header data
+  Header header                        = 1;
+  repeated string joint_names          = 2;
+  repeated JointTrajectoryPoint points = 3;
+}

--- a/proto/ignition/msgs/joint_trajectory_point.proto
+++ b/proto/ignition/msgs/joint_trajectory_point.proto
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+option java_outer_classname = "JointTrajectoryPointProtos";
+
+/// \ingroup ignition.msgs
+/// \interface JointTrajectoryPoint
+/// \brief Message for a single point in joint trajectory, used by joint_trajectory.proto
+
+import "ignition/msgs/duration.proto";
+
+message JointTrajectoryPoint
+{
+  repeated double positions     = 1;
+  repeated double velocities    = 2;
+  repeated double accelerations = 3;
+  repeated double effort        = 4;
+  Duration time_from_start      = 5;
+}

--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -1028,6 +1028,23 @@ namespace ignition
       if (elem && elem->GetText())
         meta.set_description(trimmed(elem->GetText()));
 
+      // Read the dependencies, if any.
+      elem = modelElement->FirstChildElement("depend");
+      while (elem)
+      {
+        auto modelElem = elem->FirstChildElement("model");
+        if (modelElem)
+        {
+          auto uriElem = modelElem->FirstChildElement("uri");
+          if (uriElem)
+          {
+            auto dependency = meta.add_dependencies();
+            dependency->set_uri(uriElem->GetText());
+          }
+        }
+        elem = elem->NextSiblingElement("depend");
+      }
+
       // Read the authors, if any.
       elem = modelElement->FirstChildElement("author");
       while (elem)
@@ -1130,6 +1147,16 @@ namespace ignition
         << "      <name>" << _meta.authors(i).name() << "</name>\n"
         << "      <email>" << _meta.authors(i).email() << "</email>\n"
         << "    </author>\n";
+      }
+
+      // Output dependency information.
+      for (int i = 0; i < _meta.dependencies_size(); ++i)
+      {
+        out << "    <depend>\n"
+        << "      <model>"
+        << "        <uri>" << _meta.dependencies(i).uri() << "</uri>\n"
+        << "      </model>"
+        << "    </depend>\n";
       }
 
       // Output closing tag.

--- a/src/ign.cc
+++ b/src/ign.cc
@@ -25,7 +25,12 @@
 #pragma warning(pop)
 #endif
 
+#include "ign.hh"
+
 #include <iostream>
+#include <string>
+#include <vector>
+
 #include <ignition/msgs/config.hh>
 #include <ignition/msgs/Factory.hh>
 


### PR DESCRIPTION
This PR adds `ignition.msgs.JointTrajectory`, which is currently utilised by `JointTrajectoryController` (PR - https://github.com/ignitionrobotics/ign-gazebo/pull/473). It provides time-parameterised control signal for each actuated single-axis joint in form of position, velocity, acceleration and effort.

This message is analogous to [`trajectory_msgs/msg/JointTrajectory`](https://github.com/ros2/common_interfaces/blob/foxy/trajectory_msgs/msg/JointTrajectory.msg). I opened https://github.com/ignitionrobotics/ros_ign/pull/121, which allows conversion of this message type between ROS 2 and Ignition Transport.

Note: There might not be an immediate benefit of including acceleration field, but it is added to keep consistency with the ROS msg.