### PR TITLE
Add JointTrajectory message

### DIFF
--- a/proto/ignition/msgs/joint_trajectory.proto
+++ b/proto/ignition/msgs/joint_trajectory.proto
@@ -22,7 +22,9 @@ option java_outer_classname = "JointTrajectoryProtos";
 
 /// \ingroup ignition.msgs
 /// \interface JointTrajectory
-/// \brief Message for joint trajectory, used by JointTrajectoryController plugin
+/// \brief Message for joint trajectory, which can be used to control a model
+/// with multiple single-axis joints simultaneously. This message is utilised
+/// by JointTrajectoryController plugin
 
 import "ignition/msgs/header.proto";
 import "ignition/msgs/joint_trajectory_point.proto";
@@ -31,6 +33,15 @@ message JointTrajectory
 {
   /// \brief Optional header data
   Header header                        = 1;
+
+  /// \brief Ordered list of joint names that must be active during execution
+  /// of this trajectory. The order shall correspond to the values in each
+  /// trajectory point
   repeated string joint_names          = 2;
+
+  /// \brief Ordered list of time-parameterised trajectory points, which can
+  /// describe positions, velocities, accelerations and/or effort for all
+  /// active joints at each point in time. All points must be ordered
+  /// according to their time from start, which must be strictly increasing
   repeated JointTrajectoryPoint points = 3;
 }

--- a/proto/ignition/msgs/joint_trajectory.proto
+++ b/proto/ignition/msgs/joint_trajectory.proto
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+option java_outer_classname = "JointTrajectoryProtos";
+
+/// \ingroup ignition.msgs
+/// \interface JointTrajectory
+/// \brief Message for joint trajectory, used by JointTrajectoryController plugin
+
+import "ignition/msgs/header.proto";
+import "ignition/msgs/joint_trajectory_point.proto";
+
+message JointTrajectory
+{
+  /// \brief Optional header data
+  Header header                        = 1;
+  repeated string joint_names          = 2;
+  repeated JointTrajectoryPoint points = 3;
+}

--- a/proto/ignition/msgs/joint_trajectory_point.proto
+++ b/proto/ignition/msgs/joint_trajectory_point.proto
@@ -22,15 +22,36 @@ option java_outer_classname = "JointTrajectoryPointProtos";
 
 /// \ingroup ignition.msgs
 /// \interface JointTrajectoryPoint
-/// \brief Message for a single point in joint trajectory, used by joint_trajectory.proto
+/// \brief Message that specifies the desired state of all single-axis joints
+/// at a specific trajectory point. All values for each joint must be ordered
+/// according to the joint names provided in JointTrajectory message
 
 import "ignition/msgs/duration.proto";
 
 message JointTrajectoryPoint
 {
+  /// \brief Position of each joint relative to their "0" position. Units are
+  /// dependent on the joint type, where radians are used for revolute or
+  /// continuous joints, and meters for prismatic joints
   repeated double positions     = 1;
+
+  /// \brief Rate of change in position of each joint. Units are dependent on
+  /// the joint type, where radians/second are used for revolute or continuous
+  /// joints, and meters/second for prismatic joints
   repeated double velocities    = 2;
+
+  /// \brief Rate of change in velocity of each joint. Units are dependent on
+  /// the joint type, where radians/second^2 are used for revolute or
+  /// continuous joints, and meters/second^2 for prismatic joints
   repeated double accelerations = 3;
+
+  /// \brief Torque or force applied at each joint. Units are dependent on the
+  /// joint type, where newton-meters are used for revolute or continuous
+  /// joints (torque), and newtons for prismatic joints (force)
   repeated double effort        = 4;
+
+  /// \brief Desired time from the beginning of trajectory execution until
+  /// this trajectory point should be reached. This value must be strictly
+  /// increasing for consecutive points
   Duration time_from_start      = 5;
 }

--- a/proto/ignition/msgs/joint_trajectory_point.proto
+++ b/proto/ignition/msgs/joint_trajectory_point.proto
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+option java_outer_classname = "JointTrajectoryPointProtos";
+
+/// \ingroup ignition.msgs
+/// \interface JointTrajectoryPoint
+/// \brief Message for a single point in joint trajectory, used by joint_trajectory.proto
+
+import "ignition/msgs/duration.proto";
+
+message JointTrajectoryPoint
+{
+  repeated double positions     = 1;
+  repeated double velocities    = 2;
+  repeated double accelerations = 3;
+  repeated double effort        = 4;
+  Duration time_from_start      = 5;
+}


### PR DESCRIPTION
This PR adds `ignition.msgs.JointTrajectory`, which is currently utilised by `JointTrajectoryController` (PR - https://github.com/ignitionrobotics/ign-gazebo/pull/473). It provides time-parameterised control signal for each actuated single-axis joint in form of position, velocity, acceleration and effort.

This message is analogous to [`trajectory_msgs/msg/JointTrajectory`](https://github.com/ros2/common_interfaces/blob/foxy/trajectory_msgs/msg/JointTrajectory.msg). I opened https://github.com/ignitionrobotics/ros_ign/pull/121, which allows conversion of this message type between ROS 2 and Ignition Transport.

Note: There might not be an immediate benefit of including acceleration field, but it is added to keep consistency with the ROS msg.