### PR TITLE
Added render order to material msgs

### DIFF
--- a/proto/ignition/msgs/material.proto
+++ b/proto/ignition/msgs/material.proto
@@ -118,5 +118,7 @@ message Material
   /// \brief Physically Based Rendering (PBR) material properties
   PBR pbr                = 10;
 
+  /// \brief Render order. The higher value will be rendered on top of the
+  /// other coplanar polygons
   double render_order    = 11;
 }

--- a/proto/ignition/msgs/material.proto
+++ b/proto/ignition/msgs/material.proto
@@ -117,4 +117,6 @@ message Material
 
   /// \brief Physically Based Rendering (PBR) material properties
   PBR pbr                = 10;
+
+  double render_order    = 11;
 }


### PR DESCRIPTION
This PR is part of the effort to avoid z-fighting between coplanar meshes. 

Related with https://github.com/ignitionrobotics/ign-rendering/pull/188

Signed-off-by: ahcorde <ahcorde@gmail.com>