### PR TITLE
Add windows installation; move installation in README to tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,28 +11,9 @@ Test coverage:
 
 [![codecov](https://codecov.io/gh/ignitionrobotics/ign-msgs/branch/master/graph/badge.svg)](https://codecov.io/gh/ignitionrobotics/ign-msgs)
 
-## Dependencies
-
-Install required dependencies as follows:
-
-    sudo apt-get install libprotobuf-dev protobuf-compiler libprotoc-dev libignition-math6-dev
-
 ## Installation
 
-Standard installation can be performed in UNIX systems using the following
-steps:
-
-    mkdir build/
-    cd build/
-    cmake ..
-    sudo make install
-
-## Uninstallation
-
-To uninstall the software installed with the previous steps:
-
-    cd build/
-    sudo make uninstall
+See the [installation tutorial](https://ignitionrobotics.org/api/msgs/6.2/index.html).
 
 ## Test
 

--- a/tutorials.md.in
+++ b/tutorials.md.in
@@ -6,7 +6,8 @@ Ignition @IGN_DESIGNATION_CAP@ library and how to use the library effectively.
 
 **The tutorials**
 
-1. \subpage cppgetstarted "C++ Get Started"
+1. \subpage install "Installation"
+2. \subpage cppgetstarted "C++ Get Started"
 
 ## License
 

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -1,0 +1,78 @@
+\page install Installation
+
+Next Tutorial: \ref cppgetstarted
+
+These instructions are for installing only Ignition Messages.
+If you're interested in using all the Ignition libraries, check out this [Ignition installation](https://ignitionrobotics.org/docs/latest/install).
+
+# Dependencies
+
+## UNIX
+
+Install required dependencies as follows:
+
+```
+sudo apt-get install libprotobuf-dev protobuf-compiler libprotoc-dev libignition-math6-dev
+```
+
+## Windows
+
+Install [Conda package management system](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html).
+Miniconda suffices.
+
+Create if necessary, and activate a Conda environment:
+
+```
+conda create -n ign-ws
+conda activate ign-ws
+```
+
+Install prerequisites:
+
+```
+conda install tinyxml2 protobuf --channel conda-forge
+```
+
+# Installation
+
+## UNIX
+
+Standard installation can be performed in UNIX systems using the following
+steps:
+
+```
+mkdir build/
+cd build/
+cmake ..
+sudo make install
+```
+
+## Windows
+
+This assumes you have created and activated a Conda environment while installing the Dependencies.
+
+1. Configure and build
+
+    ```
+    mkdir build
+    cd build
+    cmake .. -DBUILD_TESTING=OFF  # Optionally, -DCMAKE_INSTALL_PREFIX=path\to\install
+    cmake --build . --config Release
+    ```
+
+1. Optionally, install
+
+    ```
+    cmake --install . --config Release
+    ```
+
+# Uninstallation
+
+## UNIX
+
+To uninstall the software installed with the previous steps:
+
+```
+cd build/
+sudo make uninstall
+```

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -17,8 +17,7 @@ sudo apt-get install libprotobuf-dev protobuf-compiler libprotoc-dev libignition
 
 ## Windows
 
-Install [Conda package management system](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html).
-Miniconda suffices.
+First, follow the [ign-cmake](https://github.com/ignitionrobotics/ign-cmake) tutorial for installing Conda, Visual Studio, CMake, etc., prerequisites, and creating a Conda environment.
 
 Create if necessary, and activate a Conda environment:
 
@@ -31,6 +30,20 @@ Install prerequisites:
 
 ```
 conda install tinyxml2 protobuf --channel conda-forge
+```
+
+Install Ignition dependencies:
+
+You can view lists of dependencies:
+
+```
+conda search libignition-msgs* --channel conda-forge --info
+```
+
+Install dependencies, replacing `<#>` with the desired versions:
+
+```
+conda install libignition-cmake<#> libignition-math<#> libignition-tools<#> --channel conda-forge
 ```
 
 # Installation


### PR DESCRIPTION
Partially addresses https://github.com/ignitionrobotics/docs/issues/117 and https://github.com/ignitionrobotics/docs/issues/14#issuecomment-750431388 .

TODO: The installation URL in README currently links to `ign-msgs` tutorials main page, since the installation tutorial webpage doesn't exist yet. Somebody should change the link after this PR is deployed. Trivial fix.
