### PR TITLE
Add lightmap texcoord set field

### DIFF
--- a/proto/ignition/msgs/material.proto
+++ b/proto/ignition/msgs/material.proto
@@ -100,6 +100,9 @@ message Material
 
     /// \brief Filename of the light map.
     string light_map             = 14;
+
+    /// \brief Texture coordinate set for the light map
+    uint32 light_map_texcoord_set = 15;
   }
 
 


### PR DESCRIPTION
needed by ignitionrobotics/ign-gazebo#471

the `light_map` field was recently added but we also need to specify the texture coordinate set for the lightmap.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>