### PR TITLE
Add double sided field to material

### DIFF
--- a/proto/ignition/msgs/material.proto
+++ b/proto/ignition/msgs/material.proto
@@ -124,4 +124,8 @@ message Material
   /// \brief Render order. The higher value will be rendered on top of the
   /// other coplanar polygons
   double render_order    = 11;
+
+  /// \brief If true, the mesh that this material is applied to will be
+  /// rendered as double sided
+  bool double_sided      = 12;
 }


### PR DESCRIPTION
Add `double_sided` field to material.proto

This field has already been added to the sdf spec in https://github.com/osrf/sdformat/pull/410

related pull request in ign-gazebo that uses this field: https://github.com/ignitionrobotics/ign-gazebo/pull/599

Signed-off-by: Ian Chen <ichen@osrfoundation.org>