### PR TITLE
Support 'has' functionality in particle Emitter.

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,14 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition Msgs 6.3 to 6.4
+
+### Modifications
+
+1. **particle_emitter.proto**
+   + Fields have changed from plain data types to messages.
+       See [PR 137](https://github.com/ignitionrobotics/ign-msgs/pull/137)
+
 ## Ignition Msgs 4.X to 5.X
 
 ### Modifications

--- a/Migration.md
+++ b/Migration.md
@@ -11,7 +11,7 @@ release will remove the deprecated code.
 
 1. **particle_emitter.proto**
    + Fields have changed from plain data types to messages.
-       See [PR 137](https://github.com/ignitionrobotics/ign-msgs/pull/137)
+       * See [PR 137](https://github.com/ignitionrobotics/ign-msgs/pull/137)
 
 ## Ignition Msgs 4.X to 5.X
 

--- a/proto/ignition/msgs/particle_emitter.proto
+++ b/proto/ignition/msgs/particle_emitter.proto
@@ -24,10 +24,13 @@ option java_outer_classname = "ParticleEmitterProtos";
 /// \interface ParticleEmitter
 /// \brief Message for a particle emitter.
 
+import "ignition/msgs/boolean.proto";
 import "ignition/msgs/color.proto";
+import "ignition/msgs/float.proto";
 import "ignition/msgs/header.proto";
 import "ignition/msgs/material.proto";
 import "ignition/msgs/pose.proto";
+import "ignition/msgs/stringmsg.proto";
 import "ignition/msgs/vector3d.proto";
 
 message ParticleEmitter
@@ -63,29 +66,29 @@ message ParticleEmitter
   Vector3d size                 = 6;
 
   /// \brief How many particles per second should be emitted.
-  float rate                    = 7;
+  Float rate                    = 7;
 
   /// \brief The number of seconds the emitter is active.
-  float duration                = 8;
+  Float duration                = 8;
 
   /// \brief Whether particle emitter is enabled or not.
-  bool emitting                 = 9;
+  Boolean emitting                 = 9;
 
   /// \brief The particle dimensions (width, height, depth).
   Vector3d particle_size        = 10;
 
   /// \brief The number of seconds each particle will ’live’ for before
   /// being destroyed.
-  float lifetime                = 11;
+  Float lifetime                = 11;
 
   /// \brief The material which all particles in the emitter will use.
   Material material             = 12;
 
   /// \brief The minimum velocity each particle is emitted (m/s).
-  float min_velocity            = 13;
+  Float min_velocity            = 13;
 
   /// \brief The maximum velocity each particle is emitted (m/s).
-  float max_velocity            = 14;
+  Float max_velocity            = 14;
 
   /// \brief The starting color of the particles.
   Color color_start             = 15;
@@ -95,8 +98,8 @@ message ParticleEmitter
 
   /// \brief The amount by which to scale the particles in both x and y
   /// direction per second (screen coordinates).
-  float scale_rate              = 17;
+  Float scale_rate              = 17;
 
   /// \brief The path to the color image used as an affector.
-  string color_range_image      = 18;
+  StringMsg color_range_image      = 18;
 }


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

## Summary

The particle emitter message used plain data types. This prevents an Ignition system from knowing if a value has been set. Since we are using the emitter message as the `Component` in Ignition, we need this information.

I'm changing the message types. Since this message was just introduced the impact should be minimal.

Required by: https://github.com/ignitionrobotics/ign-gazebo/pull/651

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [X] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**