### PR TITLE
Added `particle_emitter` vector message

### DIFF
--- a/proto/ignition/msgs/particle_emitter_v.proto
+++ b/proto/ignition/msgs/particle_emitter_v.proto
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+option java_outer_classname = "ParticleEmitterVProtos";
+
+/// \ingroup ignition.msgs
+/// \interface ParticleEmitterV
+/// \brief Message for a list of particle emitters.
+
+import "ignition/msgs/header.proto";
+import "ignition/msgs/particle_emitter.proto";
+
+message ParticleEmitter_V
+{
+  /// \brief Optional header data.
+  Header header                 = 1;
+
+  /// \brief List of particle emitters.
+  repeated ParticleEmitter particle_emitter     = 2;
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary

Add a `particle_emitter_v` message which contains a `repeated ParticleEmitter`.

This is part of a series of pull requests designed to support particle emitter in gz3d.
See also:
  * https://github.com/ignitionrobotics/ign-msgs/pull/149
  * https://github.com/ignitionrobotics/ign-gazebo/pull/730
  * https://github.com/ignitionrobotics/ign-launch/pull/104
 
## Test it

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**