### PR TITLE
Bump main to 8.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-msgs7 VERSION 7.0.0)
+project(ignition-msgs8 VERSION 8.0.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Ignition Msgs 8.x
+
+### Ignition Msgs 8.0.0 (2021-xx-xx)
+
 ## Ignition Msgs 7.x
 
 ### Ignition Msgs 7.x.x (2021-xx-xx)
@@ -119,11 +123,11 @@
 
 ### Ignition Msgs 5.7.0 (2021-03-17)
 
-1. Add ignition version of nav_msgs/OccupancyGrid (backport #138) 
+1. Add ignition version of nav_msgs/OccupancyGrid (backport #138)
     * [Pull request 143](https://github.com/ignitionrobotics/ign-msgs/pull/143)
     * [Pull request 143](https://github.com/ignitionrobotics/ign-msgs/pull/138)
 
-1. Master branch updates 
+1. Master branch updates
     * [Pull request 141](https://github.com/ignitionrobotics/ign-msgs/pull/141)
 
 1. Add windows installation; move installation in README to tutorial

--- a/tutorials/cppgetstarted.md
+++ b/tutorials/cppgetstarted.md
@@ -62,7 +62,7 @@ To compile the code create a `CMakeLists.txt`:
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 # Find the Ignition msgs library
-find_package(ignition-msgs7 QUIET REQUIRED)
+find_package(ignition-msgs8 QUIET REQUIRED)
 
 add_executable(ignition-msgs-example main.cc)
 target_link_libraries(ignition-msgs-example ${IGNITION-MSGS_LIBRARIES})


### PR DESCRIPTION
Branch `ign-msgs7` has been created for the Edifice release and 7.0.0 released from that.

The `main` branch now corresponds to version 8.0.0~pre1, and nightlies will soon be created from this branch.

https://github.com/ignition-tooling/release-tools/issues/421