### PR TITLE
Add particle emitters to link.proto and add topic to particle_emitter…

### DIFF
--- a/proto/ignition/msgs/link.proto
+++ b/proto/ignition/msgs/link.proto
@@ -29,6 +29,7 @@ import "ignition/msgs/collision.proto";
 import "ignition/msgs/visual.proto";
 import "ignition/msgs/light.proto";
 import "ignition/msgs/sensor.proto";
+import "ignition/msgs/particle_emitter.proto";
 import "ignition/msgs/projector.proto";
 import "ignition/msgs/pose.proto";
 import "ignition/msgs/battery.proto";
@@ -60,4 +61,7 @@ message Link
 
   /// \brief A vector of lights attached to this link
   repeated Light light          = 17;
+
+  /// \brief A vector of particle emitters attached to this link.
+  repeated ParticleEmitter particle_emitter = 18;
 }

--- a/proto/ignition/msgs/particle_emitter.proto
+++ b/proto/ignition/msgs/particle_emitter.proto
@@ -102,4 +102,8 @@ message ParticleEmitter
 
   /// \brief The path to the color image used as an affector.
   StringMsg color_range_image      = 18;
+
+  /// \brief The topic name used by the particle emitter for control and
+  /// modification.
+  StringMsg topic                  = 19;
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary

Adds `particle_emitter` to `Link` and adds 'topic' to the 'particle_emitter'. Both of these reflect additions to [SDF](https://github.com/osrf/sdformat/pull/528).


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**