### PR TITLE
fixed a comment in the Image.proto file

### DIFF
--- a/proto/ignition/msgs/image.proto
+++ b/proto/ignition/msgs/image.proto
@@ -56,7 +56,7 @@ message Image
   /// \brief Optional header data
   Header header        = 1;
 
-  /// \brief Image wisth (number of columns)
+  /// \brief Image width (number of columns)
   uint32 width         = 2;
 
   /// \brief Image height (number of rows)


### PR DESCRIPTION
changed the spelling of `wisth` to `width`. Please follow (#160).