### PR TITLE
Add particle scatter ratio field to particle emitter

### DIFF
--- a/proto/ignition/msgs/particle_emitter.proto
+++ b/proto/ignition/msgs/particle_emitter.proto
@@ -107,11 +107,11 @@ message ParticleEmitter
   /// modification.
   StringMsg topic                  = 19;
 
-  /// \brief the Ratio of particles that will be detected by sensors.
+  /// \brief The ratio of particles that will be detected by sensors.
   /// Increasing the ratio means there is a higher chance of particles
   /// reflecting and interfering with depth sensing, making the emitter
   /// appear more dense. Decreasing the ratio decreases the chance of
   /// particles reflecting and interfering with depth sensing, making it
-  /// appear less dense.
+  /// appear less dense. Value is in the range of [0, 1].
   Float particle_scatter_ratio     = 20;
 }

--- a/proto/ignition/msgs/particle_emitter.proto
+++ b/proto/ignition/msgs/particle_emitter.proto
@@ -106,4 +106,12 @@ message ParticleEmitter
   /// \brief The topic name used by the particle emitter for control and
   /// modification.
   StringMsg topic                  = 19;
+
+  /// \brief the Ratio of particles that will be detected by sensors.
+  /// Increasing the ratio means there is a higher chance of particles
+  /// reflecting and interfering with depth sensing, making the emitter
+  /// appear more dense. Decreasing the ratio decreases the chance of
+  /// particles reflecting and interfering with depth sensing, making it
+  /// appear less dense.
+  Float particle_scatter_ratio     = 20;
 }


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

Needed by `particle_emitter2` system in ign-gazebo. See https://github.com/ignitionrobotics/ign-gazebo/pull/791#discussion_r627017214

This parameter has also been added to sdf spec in https://github.com/osrf/sdformat/pull/547

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
