### PR TITLE
Adds PerformanceSensorMetrics proto message.

### DIFF
--- a/proto/ignition/msgs/performance_sensor_metrics.proto
+++ b/proto/ignition/msgs/performance_sensor_metrics.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+package ignition.msgs;
+
+/// \brief This message contains information about the performance of
+/// a sensor in the world.
+/// If the sensor is a camera then it will publish the frame per second (fps).
+message PerformanceSensorMetrics
+{
+  /// \brief Sensor name
+  string name                 = 1;
+
+  /// \brief The update rate of the sensor in real time.
+  double real_update_rate     = 2;
+
+  /// \brief The update rate of the sensor in simulation time.
+  double sim_update_rate      = 3;
+
+  /// \brief The nominal update rate defined to the sensor.
+  double nominal_update_rate  = 4;
+
+  /// \brief If the sensor is a camera then this field should be filled
+  /// with average fps in real time.
+  double fps                  = 5;
+}

--- a/proto/ignition/msgs/performance_sensor_metrics.proto
+++ b/proto/ignition/msgs/performance_sensor_metrics.proto
@@ -1,5 +1,24 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 syntax = "proto3";
 package ignition.msgs;
+
+import "ignition/msgs/double.proto";
 
 /// \brief This message contains information about the performance of
 /// a sensor in the world.
@@ -20,5 +39,5 @@ message PerformanceSensorMetrics
 
   /// \brief If the sensor is a camera then this field should be filled
   /// with average fps in real time.
-  double fps                  = 5;
+  Double fps_optional         = 5;
 }


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/ignitionrobotics/ign-gazebo/issues/557
Related to https://github.com/ignitionrobotics/ign-sensors/pull/146

## Summary
Adds a message to publish performance metrics of the sensors.

```proto
/// \brief This message contains information about the performance of
/// a sensor in the world.
/// If the sensor is a camera then it will publish the frame per second (fps).
message PerformanceSensorMetrics
{
  /// \brief Sensor name
  string name                 = 1;

  /// \brief The update rate of the sensor in real time.
  double real_update_rate     = 2;

  /// \brief The update rate of the sensor in simulation time.
  double sim_update_rate      = 3;

  /// \brief The nominal update rate defined to the sensor.
  double nominal_update_rate  = 4;

  /// \brief If the sensor is a camera then this field should be filled
  /// with average fps in real time.
  double fps                  = 5;
}
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
