### PR TITLE
 🚫 option to terminate the world added [WIP]

### DIFF
--- a/proto/ignition/msgs/world_control.proto
+++ b/proto/ignition/msgs/world_control.proto
@@ -38,6 +38,7 @@ message WorldControl
   uint32 multi_step    = 4;
   WorldReset reset     = 5;
   uint32 seed          = 6;
+  bool terminate       = 7;
 
   // \brief A simulation time in the future to run to and then pause.
   Time run_to_sim_time = 7;

--- a/proto/ignition/msgs/world_control.proto
+++ b/proto/ignition/msgs/world_control.proto
@@ -36,11 +36,11 @@ message WorldControl
   bool pause           = 2;
   bool step            = 3;
   bool terminate       = 4;
-  uint32 multi_step    = 6;
+  uint32 multi_step    = 5;
   WorldReset reset     = 6;
   uint32 seed          = 7;
   
 
   // \brief A simulation time in the future to run to and then pause.
-  Time run_to_sim_time = 7;
+  Time run_to_sim_time = 8;
 }

--- a/proto/ignition/msgs/world_control.proto
+++ b/proto/ignition/msgs/world_control.proto
@@ -35,10 +35,11 @@ message WorldControl
 
   bool pause           = 2;
   bool step            = 3;
-  uint32 multi_step    = 4;
-  WorldReset reset     = 5;
-  uint32 seed          = 6;
-  bool terminate       = 7;
+  bool terminate       = 4;
+  uint32 multi_step    = 6;
+  WorldReset reset     = 6;
+  uint32 seed          = 7;
+  
 
   // \brief A simulation time in the future to run to and then pause.
   Time run_to_sim_time = 7;


### PR DESCRIPTION
## Summary
Added the option to stop/terminate the world.

## Desired Behavior
This functionality aims at terminating the current world in the simulation. 

## Test it
To be added

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers