### PR TITLE
scene.proto: add shadow_caster_material_name

### DIFF
--- a/proto/ignition/msgs/scene.proto
+++ b/proto/ignition/msgs/scene.proto
@@ -51,4 +51,7 @@ message Scene
 
   /// \brief Show/hide world origin indicator.
   bool origin_visual  = 12;
+
+  /// \brief Name of shadow caster material.
+  string shadow_caster_material_name = 13;
 }

--- a/proto/ignition/msgs/scene.proto
+++ b/proto/ignition/msgs/scene.proto
@@ -29,17 +29,12 @@ import "ignition/msgs/fog.proto";
 import "ignition/msgs/sky.proto";
 import "ignition/msgs/light.proto";
 import "ignition/msgs/joint.proto";
+import "ignition/msgs/material.proto";
 import "ignition/msgs/model.proto";
 import "ignition/msgs/header.proto";
 
 message Scene
 {
-  message Script
-  {
-    repeated string uri = 1;
-    string material_name = 2;
-  }
-
   /// \brief Optional header data
   Header header       = 1;
 
@@ -58,6 +53,6 @@ message Scene
   /// \brief Show/hide world origin indicator.
   bool origin_visual  = 12;
 
-  /// \brief Name of shadow caster material.
-  Script shadow_caster_script = 13;
+  /// \brief Shadow caster material script.
+  Material.Script shadow_caster_material_script = 13;
 }

--- a/proto/ignition/msgs/scene.proto
+++ b/proto/ignition/msgs/scene.proto
@@ -34,6 +34,12 @@ import "ignition/msgs/header.proto";
 
 message Scene
 {
+  message Script
+  {
+    repeated string uri = 1;
+    string material_name = 2;
+  }
+
   /// \brief Optional header data
   Header header       = 1;
 
@@ -53,5 +59,5 @@ message Scene
   bool origin_visual  = 12;
 
   /// \brief Name of shadow caster material.
-  string shadow_caster_material_name = 13;
+  Script shadow_caster_script = 13;
 }


### PR DESCRIPTION
# 🎉 New feature

Motivated by osrf/gazebo#3048.

## Summary

We added a custom SDFormat parameter in osrf/gazebo#3048 to allow specifying the name of a custom shadow caster material for a scene. Given that gazebo classic communicates scene information from the server to the client over a transport interface, it would have been convenient to add this field to the `scene.proto` message, but this would have broken ABI. As such, we added a separate ignition-transport service for this parameter.

Before ABI freezes for fortress, I thought I would submit this change, in case we decide to use the parameter in ignition in the future.

cc @iche033 @WilliamLewww 

## Test it

It's not used yet; this is just in anticipation of a future use of this parameter.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
