### PR TITLE
Fix trivial typo in command line help message

### DIFF
--- a/src/cmd/cmdmsgs.rb.in
+++ b/src/cmd/cmdmsgs.rb.in
@@ -40,7 +40,7 @@ COMMANDS = {  'msg' =>
                   "Options:\n\n" +
                   "  -i [ --info ] arg     " +
                   "Get info about the specified message type.\n" +
-                  "  -l [ --list ]         List all topics.\n" +
+                  "  -l [ --list ]         List all message types.\n" +
                   COMMON_OPTIONS
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

Typo in help message.

P.S. There is a correct description in line 68, but I don't know what that description is used for. It doesn't get printed.

## Summary

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**