### PR TITLE
Marker: support different colors per point

### DIFF
--- a/proto/ignition/msgs/marker.proto
+++ b/proto/ignition/msgs/marker.proto
@@ -64,10 +64,10 @@ message Marker
     ALL = 1;
   }
 
-  /// \brief How to interpret the data. 
+  /// \brief How to interpret the data.
   enum Action
   {
-    /// \brief Use this action to create a new marker or modify an exisiting 
+    /// \brief Use this action to create a new marker or modify an exisiting
     /// marker. A marker will be created if the provided id does not match
     /// an exisiting marker, otherwise the marker with the provided id will
     /// be modified.
@@ -94,7 +94,7 @@ message Marker
   /// \brief Namespace of the marker. A namespace groups id's together.
   ///
   /// Relevant Action: ADD_MODIFY, DELETE_MARKER, DELETE_ALL
-  string ns         = 3; 
+  string ns         = 3;
 
   /// \brief The id within the namespace of the visual. Each marker has a
   /// unique id. It's up to the user to select id values.
@@ -102,7 +102,7 @@ message Marker
   /// Relevant Action: ADD_MODIFY, DELETE_MARKER
   ///
   /// Relevant Type: all
-  uint64 id         = 4; 
+  uint64 id         = 4;
 
   /// \brief The layer the visual belongs to.
   ///
@@ -116,7 +116,7 @@ message Marker
   /// Relevant Action: ADD_MODIFY
   Type type         = 6;
 
-  /// \brief How long to keep the visual alive before deletion. A value of 
+  /// \brief How long to keep the visual alive before deletion. A value of
   /// zero indicates forever. The lifetime is based on simulation-time, not
   /// real-time.
   ///
@@ -175,4 +175,12 @@ message Marker
   ///
   /// Relevant Type: all
   Visibility visibility  = 14;
+
+  /// \brief Marker color for repeated types.
+  ///
+  /// Relevant Action: ADD_MODIFY
+  ///
+  /// Relevant Type: LINE_STRIP, LINE_LIST, POINTS, TRIANGLE_FAN, TRIANGLE_LIST,
+  /// TRIANGLE_STRIP
+  repeated Material materials = 15;
 }


### PR DESCRIPTION
# 🎉 New feature

* Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1156
* Requires https://github.com/ignition-tooling/release-tools/issues/554

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

The goal is to be able to display points with different colors. Right now, that's possible using one point per `Marker` message inside a `Marker_V`, but that hurts performance because there's a lot of duplication on each nested message.

The approach taken here is similar to the [marker message on RViz](http://wiki.ros.org/rviz/DisplayTypes/Marker#Message_Parameters).

Points only really need one color, they currently only use `diffuse` from the `material` field. I decided to go with a full `Material` message instead of just a plain color because we may want to use this field for other things like triangles in the future.

~~The branch is currently on `ign-msgs8` while I work on the implementation, but the goal is to merge this into `main` after https://github.com/ignition-tooling/release-tools/issues/554.~~ Rebased onto `main`.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

There's a demo on `ign-gui`:

* https://github.com/ignitionrobotics/ign-gui/pull/318

![pts_color](https://user-images.githubusercontent.com/5751272/144188089-7abe715f-7eb3-462e-9f2d-6ed1d5780ef0.png)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
