### PR TITLE
Add PointCloudPacked iterators

### DIFF
--- a/include/ignition/msgs/PointCloudPackedUtils.hh
+++ b/include/ignition/msgs/PointCloudPackedUtils.hh
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+// Inspired by
+// https://github.com/ros/common_msgs/blob/275b09a/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.h
+
+#ifndef IGNITION_MSGS_POINTCLOUDPACKEDUTILS_HH_
+#define IGNITION_MSGS_POINTCLOUDPACKEDUTILS_HH_
+
+#include <ignition/msgs/pointcloud_packed.pb.h>
+
+#include <cstdarg>
+#include <string>
+#include <vector>
+#include <sstream>
+
+#include "ignition/msgs/config.hh"
+#include "ignition/msgs/detail/PointCloudPackedUtils.hh"
+#include "ignition/msgs/Export.hh"
+
+namespace ignition
+{
+namespace msgs
+{
+/// \brief Class that can iterate over a PointCloudPacked message.
+///
+/// E.g, you create your message and reserve space for data as follows:
+/// \verbatim
+/// ignition::msgs::PointCloudPacked pcMsg;
+/// ignition::msgs::InitPointCloudPacked(pcMsg, "my_new_frame", false,
+///     {{"a", PointCloudPacked::Field::FLOAT32}});
+/// pcMsg.mutable_data()->resize(numPts * pcMsg.point_step());
+/// \endverbatim
+///
+/// For iterating over "s", you do :
+///
+/// \verbatim
+/// ignition::msgs::PointCloudPackedIterator<float> iterA(pcMsg, "a");
+/// \endverbatim
+///
+/// And then access it through iterA[0] or *iterA.
+///
+/// For iterating over RGBA, you can access each element as uint8_t:
+///
+/// \verbatim
+/// ignition::msgs::PointCloudPackedIterator<uint8_t> iterR(pcMsg, "r");
+/// ignition::msgs::PointCloudPackedIterator<uint8_t> iterG(pcMsg, "g");
+/// ignition::msgs::PointCloudPackedIterator<uint8_t> iterB(pcMsg, "b");
+/// ignition::msgs::PointCloudPackedIterator<uint8_t> iterA(pcMsg, "a");
+/// \endverbatim
+///
+/// \tparam FieldType Type of the element being iterated upon
+template<typename FieldType>
+class IGNITION_MSGS_VISIBLE PointCloudPackedIterator
+  : public PointCloudPackedIteratorBase<
+    FieldType, FieldType, char, PointCloudPacked, PointCloudPackedIterator>
+{
+  // Documentation inherited
+  public: PointCloudPackedIterator(PointCloudPacked &_cloudMsg,
+    const std::string &_fieldName)
+      : PointCloudPackedIteratorBase<FieldType, FieldType, char, PointCloudPacked,
+      PointCloudPackedIterator>::PointCloudPackedIteratorBase(_cloudMsg, _fieldName)
+  {
+  }
+};
+
+/// \brief Same as a PointCloudPackedIterator but for const data
+/// \tparam FieldType Type of the element being iterated upon
+template<typename FieldType>
+class IGNITION_MSGS_VISIBLE PointCloudPackedConstIterator
+  : public PointCloudPackedIteratorBase<
+    FieldType, const FieldType, const char, const PointCloudPacked,
+    PointCloudPackedConstIterator>
+{
+  public: PointCloudPackedConstIterator(
+      const PointCloudPacked &_cloudMsg,
+      const std::string &_fieldName)
+    : PointCloudPackedIteratorBase<FieldType, const FieldType, const char,
+        const PointCloudPacked,
+        PointCloudPackedConstIterator
+    >::PointCloudPackedIteratorBase(_cloudMsg, _fieldName)
+    {
+    }
+};
+
+/// \brief Return the size of a datatype (which is an enum of
+/// ignition::msgs::PointCloudPacked::Field) in bytes.
+/// \param[in] _dataType One of the enums of
+///            ignition::msgs::PointCloudPacked::Field
+/// \return Size in bytes. Returns -1 if the type is unknown.
+inline int IGNITION_MSGS_VISIBLE sizeOfPointField(
+    PointCloudPacked::Field::DataType _dataType)
+{
+  if ((_dataType == PointCloudPacked::Field::INT8) ||
+      (_dataType == PointCloudPacked::Field::UINT8))
+  {
+    return 1;
+  }
+  else if ((_dataType == PointCloudPacked::Field::INT16) ||
+           (_dataType == PointCloudPacked::Field::UINT16))
+  {
+    return 2;
+  }
+  else if ((_dataType == PointCloudPacked::Field::INT32) ||
+           (_dataType == PointCloudPacked::Field::UINT32) ||
+           (_dataType == PointCloudPacked::Field::FLOAT32))
+  {
+    return 4;
+  }
+  else if (_dataType == PointCloudPacked::Field::FLOAT64)
+  {
+    return 8;
+  }
+  else
+  {
+    std::cerr << "PointCloudPacked::Field of type [" << _dataType
+              << "] does not exist" << std::endl;
+  }
+  return -1;
+}
+}
+}
+
+#endif

--- a/include/ignition/msgs/PointCloudPackedUtils.hh
+++ b/include/ignition/msgs/PointCloudPackedUtils.hh
@@ -72,8 +72,9 @@ class IGNITION_MSGS_VISIBLE PointCloudPackedIterator
   // Documentation inherited
   public: PointCloudPackedIterator(PointCloudPacked &_cloudMsg,
     const std::string &_fieldName)
-      : PointCloudPackedIteratorBase<FieldType, FieldType, char, PointCloudPacked,
-      PointCloudPackedIterator>::PointCloudPackedIteratorBase(_cloudMsg, _fieldName)
+      : PointCloudPackedIteratorBase<FieldType, FieldType, char,
+        PointCloudPacked, PointCloudPackedIterator>
+        ::PointCloudPackedIteratorBase(_cloudMsg, _fieldName)
   {
   }
 };

--- a/include/ignition/msgs/detail/PointCloudPackedUtils.hh
+++ b/include/ignition/msgs/detail/PointCloudPackedUtils.hh
@@ -1,0 +1,439 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+// Inspired by
+// https://github.com/ros/common_msgs/blob/275b09a/sensor_msgs/include/sensor_msgs/point_cloud2_iterator.h
+
+#ifndef IGNITION_MSGS_DETAIL_POINTCLOUDPACKEDUTILS_HH_
+#define IGNITION_MSGS_DETAIL_POINTCLOUDPACKEDUTILS_HH_
+
+#include <ignition/msgs/pointcloud_packed.pb.h>
+
+#include <string>
+
+#include "ignition/msgs/config.hh"
+#include "ignition/msgs/Export.hh"
+
+namespace ignition
+{
+namespace msgs
+{
+/// \brief Private base class for PointCloudPackedIterator and
+/// PointCloudPackedConstIterator.
+/// \tparam FieldType The type of the value on which the child class will be
+///         templated.
+/// \tparam QualifiedFieldType The type of the value to be retrieved (same as
+///         FieldType except that it may be const).
+/// \tparam RawDataType The type of the raw data in PointCloudPacked (only
+///        `char` and `const char` are supported)
+/// \tparam PointCloudType Either `PointCloudPacked` or `const PointCloudPacked`
+/// \tparam DerivedClass The derived class.
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+class IGNITION_MSGS_HIDDEN PointCloudPackedIteratorBase
+{
+  /// \brief Constructor
+  /// \param[in] _cloudMsg The PointCloudPacked to iterate upon
+  /// \param[in] _fieldName The field to iterate upon
+  public: PointCloudPackedIteratorBase(PointCloudType &_cloudMsg,
+      const std::string &_fieldName);
+
+  /// \brief Copy assignment operator
+  /// \param[in] _iter The iterator to copy data from
+  /// \return A reference to *this
+  public: DerivedClass<FieldType> &operator=(
+      const DerivedClass<FieldType> &_iter);
+
+  /// \brief Access the i th element starting at the current pointer (useful
+  /// when a field has several elements of the same type)
+  /// \param[in] _i Element index
+  /// \return A reference to the i th value from the current position.
+  public: QualifiedFieldType &operator[](size_t _i) const;
+
+  /// \brief Dereference the iterator. Equivalent to accessing it through [n].
+  /// \return The value to which the iterator is pointing.
+  public: QualifiedFieldType &operator*() const;
+
+  /// \brief Increase the iterator to the next element.
+  /// \return A reference to the updated iterator.
+  public: DerivedClass<FieldType> &operator++();
+
+  /// \brief Basic pointer addition.
+  /// \param[in] _i The amount to increase the iterator by
+  /// \return An iterator with an increased position
+  public: DerivedClass<FieldType> operator+(int _i);
+
+  /// \brief Increase the iterator by a certain amount.
+  /// \param[in] _i The amount to increase the iterator by
+  /// \return A reference to the updated iterator.
+  public: DerivedClass<FieldType> &operator+=(int _i);
+
+  /// \brief Compare to another iterator
+  /// \return True if the current iterator points to a different address than
+  /// the other one
+  public: bool operator!=(const DerivedClass<FieldType> &_iter) const;
+
+  /// \brief Compare to another iterator
+  /// \return True if the current iterator points to the same address as
+  /// the other one
+  public: bool operator==(const DerivedClass<FieldType> &_iter) const;
+
+  /// \brief Return the end iterator.
+  /// \return The end iterator (useful when performing normal iterator
+  /// processing with ++).
+  public: DerivedClass<FieldType> End() const;
+
+  /// \brief Common code to set the field of the PointCloudPacked message.
+  /// \param[in] _cloudMsg the PointCloudPacked to modify.
+  /// \param[in] _fieldName the name of the field to set.
+  /// \return The offset at which the field is found, or -1 if field doesn't
+  ///         exist.
+  private: int SetField(const PointCloudPacked &_cloudMsg,
+      const std::string &_fieldName);
+
+  /// \brief The "point_step" of the original cloud
+  private: int pointStep{0};
+
+  /// \brief The raw data in where the iterator is
+  private: RawDataType *dataChar{nullptr};
+
+  /// \brief The cast data where the iterator is
+  private: QualifiedFieldType *data{nullptr};
+
+  /// \brief The end() pointer of the iterator
+  private: QualifiedFieldType *dataEnd{nullptr};
+
+  /// \brief Whether the fields are stored as bigendian
+  private: bool isBigendian{false};
+};
+
+//////////////////////////////////////////////////
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+PointCloudPackedIteratorBase<
+    FieldType,
+    QualifiedFieldType,
+    RawDataType,
+    PointCloudType,
+    DerivedClass>
+    ::PointCloudPackedIteratorBase(
+        PointCloudType &_cloudMsg,
+        const std::string &_fieldName)
+{
+  int offset = this->SetField(_cloudMsg, _fieldName);
+  if (offset < 0)
+  {
+    this->data = nullptr;
+    this->dataChar = nullptr;
+    this->dataEnd = nullptr;
+  }
+  else
+  {
+    this->dataChar = const_cast<RawDataType *>(&(_cloudMsg.data().front()))
+        + offset;
+    this->data = reinterpret_cast<QualifiedFieldType *>(this->dataChar);
+    this->dataEnd = reinterpret_cast<QualifiedFieldType *>(const_cast<char *>(
+        &(_cloudMsg.data().back())) + 1 + offset);
+  }
+}
+
+//////////////////////////////////////////////////
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+DerivedClass<FieldType> &PointCloudPackedIteratorBase<
+    FieldType,
+    QualifiedFieldType,
+    RawDataType,
+    PointCloudType,
+    DerivedClass>::operator=(const DerivedClass<FieldType> &_iter)
+{
+  if (this != &_iter)
+  {
+    this->pointStep = _iter.pointStep;
+    this->dataChar = _iter.dataChar;
+    this->data = _iter.data;
+    this->dataEnd = _iter.dataEnd;
+    this->isBigendian = _iter.isBigendian;
+  }
+
+  return *this;
+}
+
+//////////////////////////////////////////////////
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+QualifiedFieldType &PointCloudPackedIteratorBase<
+    FieldType,
+    QualifiedFieldType,
+    RawDataType,
+    PointCloudType,
+    DerivedClass>::operator[](size_t i) const
+{
+  return *(this->data + i);
+}
+
+//////////////////////////////////////////////////
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+QualifiedFieldType &PointCloudPackedIteratorBase<
+    FieldType,
+    QualifiedFieldType,
+    RawDataType,
+    PointCloudType,
+    DerivedClass>::operator*() const
+{
+  return *this->data;
+}
+
+//////////////////////////////////////////////////
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+DerivedClass<FieldType> & PointCloudPackedIteratorBase<
+    FieldType,
+    QualifiedFieldType,
+    RawDataType,
+    PointCloudType,
+    DerivedClass>::operator++()
+{
+  this->dataChar += this->pointStep;
+  this->data = reinterpret_cast<QualifiedFieldType *>(this->dataChar);
+  return *static_cast<DerivedClass<FieldType> *>(this);
+}
+
+//////////////////////////////////////////////////
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+DerivedClass<FieldType> PointCloudPackedIteratorBase<
+    FieldType,
+    QualifiedFieldType,
+    RawDataType,
+    PointCloudType,
+    DerivedClass>::operator+(int i)
+{
+  DerivedClass<FieldType> res = *static_cast<DerivedClass<FieldType> *>(this);
+
+  res.dataChar += i * this->pointStep;
+  res.data = reinterpret_cast<QualifiedFieldType *>(res.dataChar);
+
+  return res;
+}
+
+//////////////////////////////////////////////////
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+DerivedClass<FieldType> & PointCloudPackedIteratorBase<
+    FieldType,
+    QualifiedFieldType,
+    RawDataType,
+    PointCloudType,
+    DerivedClass>::operator+=(int i)
+{
+  this->dataChar += i * this->pointStep;
+  this->data = reinterpret_cast<QualifiedFieldType *>(this->dataChar);
+  return *static_cast<DerivedClass<FieldType> *>(this);
+}
+
+//////////////////////////////////////////////////
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+bool PointCloudPackedIteratorBase<
+    FieldType,
+    QualifiedFieldType,
+    RawDataType,
+    PointCloudType,
+    DerivedClass>::operator!=(const DerivedClass<FieldType> &_iter) const
+{
+  return _iter.data != this->data;
+}
+
+//////////////////////////////////////////////////
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+bool PointCloudPackedIteratorBase<
+    FieldType,
+    QualifiedFieldType,
+    RawDataType,
+    PointCloudType,
+    DerivedClass>::operator==(const DerivedClass<FieldType> &_iter) const
+{
+  return _iter.data == this->data;
+}
+
+//////////////////////////////////////////////////
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+DerivedClass<FieldType> PointCloudPackedIteratorBase<
+    FieldType,
+    QualifiedFieldType,
+    RawDataType,
+    PointCloudType,
+    DerivedClass>::End() const
+{
+  DerivedClass<FieldType> res = *static_cast<const DerivedClass<FieldType> *>(this);
+  res.data = this->dataEnd;
+  return res;
+}
+
+//////////////////////////////////////////////////
+template<
+    typename FieldType,
+    typename QualifiedFieldType,
+    typename RawDataType,
+    typename PointCloudType,
+    template<typename> class DerivedClass>
+int PointCloudPackedIteratorBase<
+    FieldType,
+    QualifiedFieldType,
+    RawDataType,
+    PointCloudType,
+    DerivedClass>::SetField(
+        const PointCloudPacked &_cloudMsg,
+        const std::string &_fieldName)
+{
+  this->isBigendian = _cloudMsg.is_bigendian();
+  this->pointStep = _cloudMsg.point_step();
+  // make sure the channel is valid
+  auto fieldIter = _cloudMsg.field().begin();
+  auto fieldEnd = _cloudMsg.field().end();
+  while ((fieldIter != fieldEnd) && (fieldIter->name() != _fieldName))
+  {
+    ++fieldIter;
+  }
+
+  if (fieldIter == fieldEnd)
+  {
+    // Handle the special case of r,g,b,a (we assume they are understood as the
+    // channels of an rgb or rgba field)
+    if ((_fieldName == "r") ||
+        (_fieldName == "g") ||
+        (_fieldName == "b") ||
+        (_fieldName == "a"))
+    {
+      // Check that rgb or rgba is present
+      fieldIter = _cloudMsg.field().begin();
+      while ((fieldIter != fieldEnd) && (fieldIter->name() != "rgb") &&
+        (fieldIter->name() != "rgba"))
+      {
+        ++fieldIter;
+      }
+      if (fieldIter == fieldEnd)
+      {
+        std::cerr << "Field [" << _fieldName << "] does not exist."
+                  << std::endl;
+        return -1;
+      }
+      if (_fieldName == "r")
+      {
+        if (this->isBigendian)
+        {
+          return fieldIter->offset() + 1;
+        }
+        else
+        {
+          return fieldIter->offset() + 2;
+        }
+      }
+      if (_fieldName == "g")
+      {
+        if (this->isBigendian)
+        {
+          return fieldIter->offset() + 2;
+        }
+        else
+        {
+          return fieldIter->offset() + 1;
+        }
+      }
+      if (_fieldName == "b")
+      {
+        if (this->isBigendian)
+        {
+          return fieldIter->offset() + 3;
+        }
+        else
+        {
+          return fieldIter->offset() + 0;
+        }
+      }
+      if (_fieldName == "a")
+      {
+        if (this->isBigendian)
+        {
+          return fieldIter->offset() + 0;
+        }
+        else
+        {
+          return fieldIter->offset() + 3;
+        }
+      }
+    }
+    else
+    {
+      std::cerr << "Field [" << _fieldName << "] does not exist." << std::endl;
+      return -1;
+    }
+  }
+
+  return fieldIter->offset();
+}
+}
+}
+#endif

--- a/include/ignition/msgs/detail/PointCloudPackedUtils.hh
+++ b/include/ignition/msgs/detail/PointCloudPackedUtils.hh
@@ -327,7 +327,8 @@ DerivedClass<FieldType> PointCloudPackedIteratorBase<
     PointCloudType,
     DerivedClass>::End() const
 {
-  DerivedClass<FieldType> res = *static_cast<const DerivedClass<FieldType> *>(this);
+  DerivedClass<FieldType> res =
+      *static_cast<const DerivedClass<FieldType> *>(this);
   res.data = this->dataEnd;
   return res;
 }

--- a/src/PointCloudPackedUtils_TEST.cc
+++ b/src/PointCloudPackedUtils_TEST.cc
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include "ignition/msgs/PointCloudPackedUtils.hh"
+#include "ignition/msgs/Utility.hh"
+
+using namespace ignition;
+using namespace msgs;
+
+/////////////////////////////////////////////////
+TEST(PointCloudPackedUtilsTest, BadFields)
+{
+  PointCloudPacked pcMsg;
+
+  PointCloudPackedIterator<int8_t> xIter(pcMsg, "x");
+  EXPECT_EQ(xIter, xIter.End());
+
+  PointCloudPackedIterator<int8_t> xyzIter(pcMsg, "xyz");
+  EXPECT_EQ(xyzIter, xyzIter.End());
+
+  PointCloudPackedIterator<int8_t> rIter(pcMsg, "r");
+  EXPECT_EQ(rIter, rIter.End());
+}
+
+/////////////////////////////////////////////////
+TEST(PointCloudPackedUtilsTest, Operators)
+{
+  PointCloudPacked pcMsg;
+
+  InitPointCloudPacked(pcMsg, "my_new_frame", false,
+      {{"a", PointCloudPacked::Field::FLOAT32}});
+
+  EXPECT_EQ("a", pcMsg.field(0).name());
+  EXPECT_EQ(0u, pcMsg.field(0).offset());
+  EXPECT_EQ(4u, pcMsg.point_step());
+
+  // Reserve space for data
+  unsigned int total{5 * pcMsg.point_step()};
+  pcMsg.mutable_data()->resize(total);
+
+  // Populate using an iterator
+  PointCloudPackedIterator<float> a1Iter(pcMsg, "a");
+  EXPECT_NE(a1Iter, a1Iter.End());
+
+  unsigned int i = 0;
+  for (; a1Iter != a1Iter.End(); ++i, ++a1Iter)
+  {
+    float value = i * 2.0;
+    *a1Iter = value;
+
+    EXPECT_DOUBLE_EQ(value, *a1Iter);
+  }
+  EXPECT_EQ(i * pcMsg.point_step(), total);
+  EXPECT_EQ(a1Iter, a1Iter.End());
+
+  // Access operator
+  PointCloudPackedIterator<float> a2Iter(pcMsg, "a");
+  EXPECT_FLOAT_EQ(0.0, a2Iter[0]);
+  EXPECT_FLOAT_EQ(2.0, a2Iter[1]);
+  EXPECT_FLOAT_EQ(4.0, a2Iter[2]);
+  EXPECT_FLOAT_EQ(6.0, a2Iter[3]);
+  EXPECT_FLOAT_EQ(8.0, a2Iter[4]);
+
+  // Copy constructor
+  auto a3Iter = a2Iter;
+  EXPECT_EQ(a3Iter, a2Iter);
+  EXPECT_FLOAT_EQ(0.0, a3Iter[0]);
+  EXPECT_FLOAT_EQ(2.0, a3Iter[1]);
+  EXPECT_FLOAT_EQ(4.0, a3Iter[2]);
+  EXPECT_FLOAT_EQ(6.0, a3Iter[3]);
+  EXPECT_FLOAT_EQ(8.0, a3Iter[4]);
+
+  // + operator
+  auto a4Iter = a2Iter + 2;
+  EXPECT_NE(a4Iter, a2Iter);
+  EXPECT_FLOAT_EQ(4.0, a4Iter[0]);
+  EXPECT_FLOAT_EQ(6.0, a4Iter[1]);
+  EXPECT_FLOAT_EQ(8.0, a4Iter[2]);
+
+  a4Iter += 1;
+  EXPECT_FLOAT_EQ(6.0, a4Iter[0]);
+  EXPECT_FLOAT_EQ(8.0, a4Iter[1]);
+}
+
+/////////////////////////////////////////////////
+TEST(PointCloudPackedUtilsTest, MultipleFields)
+{
+  PointCloudPacked pcMsg;
+
+  InitPointCloudPacked(pcMsg, "my_new_frame", false,
+      {{"x", PointCloudPacked::Field::INT8},
+       {"y", PointCloudPacked::Field::UINT8},
+       {"z", PointCloudPacked::Field::INT16},
+       {"r", PointCloudPacked::Field::UINT16},
+       {"s", PointCloudPacked::Field::INT32},
+       {"t", PointCloudPacked::Field::UINT32},
+       {"u", PointCloudPacked::Field::FLOAT64}});
+  EXPECT_EQ(7, pcMsg.field_size());
+
+  EXPECT_EQ("x", pcMsg.field(0).name());
+  EXPECT_EQ(0u, pcMsg.field(0).offset());
+  EXPECT_EQ(msgs::PointCloudPacked::Field::INT8, pcMsg.field(0).datatype());
+  EXPECT_EQ(1u, pcMsg.field(0).count());
+
+  EXPECT_EQ("y", pcMsg.field(1).name());
+  EXPECT_EQ(1u, pcMsg.field(1).offset());
+  EXPECT_EQ(msgs::PointCloudPacked::Field::UINT8, pcMsg.field(1).datatype());
+  EXPECT_EQ(1u, pcMsg.field(1).count());
+
+  EXPECT_EQ("z", pcMsg.field(2).name());
+  EXPECT_EQ(2u, pcMsg.field(2).offset());
+  EXPECT_EQ(msgs::PointCloudPacked::Field::INT16, pcMsg.field(2).datatype());
+  EXPECT_EQ(1u, pcMsg.field(2).count());
+
+  // Reserve space for data
+  unsigned int total{5 * pcMsg.point_step()};
+  pcMsg.mutable_data()->resize(total);
+
+  PointCloudPackedIterator<int8_t> xIter(pcMsg, "x");
+  PointCloudPackedIterator<uint8_t> yIter(pcMsg, "y");
+  PointCloudPackedIterator<int16_t> zIter(pcMsg, "z");
+  PointCloudPackedIterator<uint16_t> rIter(pcMsg, "r");
+  PointCloudPackedIterator<int32_t> sIter(pcMsg, "s");
+  PointCloudPackedIterator<uint32_t> tIter(pcMsg, "t");
+  PointCloudPackedIterator<float> uIter(pcMsg, "u");
+
+  EXPECT_NE(xIter, xIter.End());
+  EXPECT_NE(yIter, yIter.End());
+  EXPECT_NE(zIter, zIter.End());
+  EXPECT_NE(rIter, rIter.End());
+  EXPECT_NE(sIter, sIter.End());
+  EXPECT_NE(tIter, tIter.End());
+  EXPECT_NE(uIter, uIter.End());
+
+  unsigned int i = 0;
+  for (; xIter != xIter.End(); ++i,
+      ++xIter,
+      ++yIter,
+      ++zIter,
+      ++rIter,
+      ++sIter,
+      ++tIter,
+      ++uIter)
+  {
+    *xIter = i;
+    *yIter = i + 1;
+    *zIter = i + 2;
+    *rIter = i + 3;
+    *sIter = i + 4;
+    *tIter = i + 5;
+    *uIter = i + 6;
+  }
+  EXPECT_EQ(i * pcMsg.point_step(), total);
+
+  EXPECT_EQ(xIter, xIter.End());
+  EXPECT_EQ(yIter, yIter.End());
+  EXPECT_EQ(zIter, zIter.End());
+  EXPECT_EQ(rIter, rIter.End());
+  EXPECT_EQ(sIter, sIter.End());
+  EXPECT_EQ(tIter, tIter.End());
+  EXPECT_EQ(uIter, uIter.End());
+
+  // Const the cloud with const iterators
+  PointCloudPackedConstIterator<int8_t> xIterConst(pcMsg, "x");
+  PointCloudPackedConstIterator<uint8_t> yIterConst(pcMsg, "y");
+  PointCloudPackedConstIterator<int16_t> zIterConst(pcMsg, "z");
+  PointCloudPackedConstIterator<uint16_t> rIterConst(pcMsg, "r");
+  PointCloudPackedConstIterator<int32_t> sIterConst(pcMsg, "s");
+  PointCloudPackedConstIterator<uint32_t> tIterConst(pcMsg, "t");
+  PointCloudPackedConstIterator<float> uIterConst(pcMsg, "u");
+
+  EXPECT_NE(xIterConst, xIterConst.End());
+  EXPECT_NE(yIterConst, yIterConst.End());
+  EXPECT_NE(zIterConst, zIterConst.End());
+  EXPECT_NE(rIterConst, rIterConst.End());
+  EXPECT_NE(sIterConst, sIterConst.End());
+  EXPECT_NE(tIterConst, tIterConst.End());
+  EXPECT_NE(uIterConst, uIterConst.End());
+
+  i = 0u;
+  for (; xIterConst != xIterConst.End(); ++i,
+      ++xIterConst,
+      ++yIterConst,
+      ++zIterConst,
+      ++rIterConst,
+      ++sIterConst,
+      ++tIterConst,
+      ++uIterConst)
+  {
+    EXPECT_EQ(static_cast<int>(i), *xIterConst);
+    EXPECT_EQ(i + 1u, *yIterConst);
+    EXPECT_EQ(static_cast<int>(i + 2), *zIterConst);
+    EXPECT_EQ(i + 3u, *rIterConst);
+    EXPECT_EQ(static_cast<int>(i + 4), *sIterConst);
+    EXPECT_EQ(i + 5u, *tIterConst);
+    EXPECT_DOUBLE_EQ(i + 6, *uIterConst);
+  }
+  EXPECT_EQ(i * pcMsg.point_step(), total);
+
+  EXPECT_EQ(xIterConst, xIterConst.End());
+  EXPECT_EQ(yIterConst, yIterConst.End());
+  EXPECT_EQ(zIterConst, zIterConst.End());
+  EXPECT_EQ(rIterConst, rIterConst.End());
+  EXPECT_EQ(sIterConst, sIterConst.End());
+  EXPECT_EQ(tIterConst, tIterConst.End());
+  EXPECT_EQ(uIterConst, uIterConst.End());
+}
+
+/////////////////////////////////////////////////
+TEST(PointCloudPackedUtilsTest, XYZRGBA)
+{
+  PointCloudPacked pcMsg;
+
+  msgs::InitPointCloudPacked(pcMsg, "my_frame", true,
+      {{"xyz", msgs::PointCloudPacked::Field::FLOAT32},
+      {"rgba", msgs::PointCloudPacked::Field::FLOAT32}});
+
+  // Reserve space for data
+  unsigned int total{5 * pcMsg.point_step()};
+  pcMsg.mutable_data()->resize(total);
+
+  // Populate using iterators
+  PointCloudPackedIterator<float> xIter(pcMsg, "x");
+  PointCloudPackedIterator<float> yIter(pcMsg, "y");
+  PointCloudPackedIterator<float> zIter(pcMsg, "z");
+  PointCloudPackedIterator<uint8_t> rIter(pcMsg, "r");
+  PointCloudPackedIterator<uint8_t> gIter(pcMsg, "g");
+  PointCloudPackedIterator<uint8_t> bIter(pcMsg, "b");
+  PointCloudPackedIterator<uint8_t> aIter(pcMsg, "a");
+  EXPECT_NE(xIter, xIter.End());
+  EXPECT_NE(yIter, yIter.End());
+  EXPECT_NE(zIter, zIter.End());
+  EXPECT_NE(rIter, rIter.End());
+  EXPECT_NE(gIter, gIter.End());
+  EXPECT_NE(bIter, bIter.End());
+  EXPECT_NE(aIter, aIter.End());
+
+  unsigned int i = 0;
+  for (; xIter != xIter.End(); ++i,
+      ++xIter, ++yIter, ++zIter, ++rIter, ++gIter, ++bIter, ++aIter)
+  {
+    *xIter = i * 2.0;
+    *yIter = i * 4.0;
+    *zIter = i * 6.0;
+    *rIter = i * 10;
+    *gIter = i * 20;
+    *bIter = i * 30;
+    *aIter = i * 40;
+  }
+  EXPECT_EQ(i * pcMsg.point_step(), total);
+  EXPECT_EQ(xIter, xIter.End());
+  EXPECT_EQ(yIter, yIter.End());
+  EXPECT_EQ(zIter, zIter.End());
+  EXPECT_EQ(rIter, rIter.End());
+  EXPECT_EQ(gIter, gIter.End());
+  EXPECT_EQ(bIter, bIter.End());
+  EXPECT_EQ(aIter, aIter.End());
+
+  // Check
+  PointCloudPackedConstIterator<float> xIterConst(pcMsg, "x");
+  PointCloudPackedConstIterator<float> yIterConst(pcMsg, "y");
+  PointCloudPackedConstIterator<float> zIterConst(pcMsg, "z");
+  PointCloudPackedConstIterator<uint8_t> rIterConst(pcMsg, "r");
+  PointCloudPackedConstIterator<uint8_t> gIterConst(pcMsg, "g");
+  PointCloudPackedConstIterator<uint8_t> bIterConst(pcMsg, "b");
+  PointCloudPackedConstIterator<uint8_t> aIterConst(pcMsg, "a");
+
+  i = 0;
+  for (; xIterConst != xIterConst.End(); ++i,
+      ++xIterConst, ++yIterConst, ++zIterConst,
+      ++rIterConst, ++gIterConst, ++bIterConst, ++aIterConst)
+  {
+    EXPECT_DOUBLE_EQ(*xIterConst, i * 2.0);
+    EXPECT_DOUBLE_EQ(*yIterConst, i * 4.0);
+    EXPECT_DOUBLE_EQ(*zIterConst, i * 6.0);
+    EXPECT_EQ(*rIterConst, i * 10);
+    EXPECT_EQ(*gIterConst, i * 20);
+    EXPECT_EQ(*bIterConst, i * 30);
+    EXPECT_EQ(*aIterConst, i * 40);
+  }
+  EXPECT_EQ(i * pcMsg.point_step(), total);
+  EXPECT_EQ(xIterConst, xIterConst.End());
+  EXPECT_EQ(yIterConst, yIterConst.End());
+  EXPECT_EQ(zIterConst, zIterConst.End());
+  EXPECT_EQ(rIterConst, rIterConst.End());
+  EXPECT_EQ(gIterConst, gIterConst.End());
+  EXPECT_EQ(bIterConst, bIterConst.End());
+  EXPECT_EQ(aIterConst, aIterConst.End());
+}
+
+/////////////////////////////////////////////////
+TEST(PointCloudPackedUtilsTest, SizeOfPointField)
+{
+  EXPECT_EQ(1, sizeOfPointField(PointCloudPacked::Field::INT8));
+  EXPECT_EQ(1, sizeOfPointField(PointCloudPacked::Field::UINT8));
+  EXPECT_EQ(2, sizeOfPointField(PointCloudPacked::Field::INT16));
+  EXPECT_EQ(2, sizeOfPointField(PointCloudPacked::Field::UINT16));
+  EXPECT_EQ(4, sizeOfPointField(PointCloudPacked::Field::INT32));
+  EXPECT_EQ(4, sizeOfPointField(PointCloudPacked::Field::UINT32));
+  EXPECT_EQ(4, sizeOfPointField(PointCloudPacked::Field::FLOAT32));
+  EXPECT_EQ(8, sizeOfPointField(PointCloudPacked::Field::FLOAT64));
+}
+


### PR DESCRIPTION
# 🎉 New feature

* Part of https://github.com/ignitionrobotics/ign-gazebo/issues/1156

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Our `PointCloudPacked` message is equivalent to ROS's `PointCloud2`, but we don't have a good way of handling our message purely from Ignition.

This PR adapts [PointCloud2Iterator](https://github.com/ros2/common_interfaces/blob/master/sensor_msgs/include/sensor_msgs/impl/point_cloud2_iterator.hpp) for Ignition.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

Run the tests

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
