### PR TITLE
Add message definitions for the parameter system

### DIFF
--- a/proto/ignition/msgs/parameter.proto
+++ b/proto/ignition/msgs/parameter.proto
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+
+/// \brief Representation of a parameter
+message Parameter
+{
+  /// \brief Parameter name;
+  string name = 1;
+
+  /// \brief Component type name;
+  string type = 2;
+
+  /// \brief Serialized component data.
+  bytes value = 3;
+};

--- a/proto/ignition/msgs/parameter.proto
+++ b/proto/ignition/msgs/parameter.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2022 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,15 @@ syntax = "proto3";
 package ignition.msgs;
 option java_package = "com.ignition.msgs";
 
-/// \brief Representation of a parameter
+/// \brief Representation of a parameter, used to request to set a parameter.
 message Parameter
 {
-  /// \brief Parameter name;
+  /// \brief Parameter name.
   string name = 1;
 
-  /// \brief Component type name;
+  /// \brief Parameter type, i.e. the associated protobuf type.
   string type = 2;
 
-  /// \brief Serialized component data.
+  /// \brief Serialized protobuf message.
   bytes value = 3;
 };

--- a/proto/ignition/msgs/parameter_declaration.proto
+++ b/proto/ignition/msgs/parameter_declaration.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2022 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ option java_package = "com.ignition.msgs";
 
 import "ignition/msgs/parameter.proto";
 
-/// \brief Representation of a parameter declaration
+/// \brief Representation of a parameter declaration.
 message ParameterDeclaration
 {
   /// \brief Parameter name.

--- a/proto/ignition/msgs/parameter_declaration.proto
+++ b/proto/ignition/msgs/parameter_declaration.proto
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+
+import "ignition/msgs/parameter.proto";
+
+/// \brief Representation of a parameter declaration
+message ParameterDeclaration
+{
+  /// \brief Parameter definition;
+  Parameter param = 1;
+
+  /// \brief Id of the entity declaring the parameter.
+  uint64 entity_id = 2;
+};

--- a/proto/ignition/msgs/parameter_declaration.proto
+++ b/proto/ignition/msgs/parameter_declaration.proto
@@ -28,7 +28,7 @@ message ParameterDeclaration
   /// \brief Parameter name.
   string name = 1;
 
-  /// \brief Parameter type, i.e. the component type.
+  /// \brief Parameter type, i.e. the associated protobuf type.
   string type = 2;
 
   /// \brief Associated component id.
@@ -36,4 +36,7 @@ message ParameterDeclaration
 
   /// \brief Associated component type id.
   uint64 component_type_id = 4;
+
+  /// \brief Associated entity id.
+  uint64 entity_id = 5;
 };

--- a/proto/ignition/msgs/parameter_declaration.proto
+++ b/proto/ignition/msgs/parameter_declaration.proto
@@ -30,13 +30,4 @@ message ParameterDeclaration
 
   /// \brief Parameter type, i.e. the associated protobuf type.
   string type = 2;
-
-  /// \brief Associated component id.
-  uint64 component_id = 3;
-
-  /// \brief Associated component type id.
-  uint64 component_type_id = 4;
-
-  /// \brief Associated entity id.
-  uint64 entity_id = 5;
 };

--- a/proto/ignition/msgs/parameter_declarations.proto
+++ b/proto/ignition/msgs/parameter_declarations.proto
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+
+import "ignition/msgs/parameter_declaration.proto";
+
+/// \brief Representation of a parameter
+message ParameterDeclarations
+{
+  /// \brief Parameter declarations;
+  repeated ParameterDeclaration parameter_declarations = 1;
+};

--- a/proto/ignition/msgs/parameter_declarations.proto
+++ b/proto/ignition/msgs/parameter_declarations.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2022 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,9 @@ option java_package = "com.ignition.msgs";
 
 import "ignition/msgs/parameter_declaration.proto";
 
-/// \brief Representation of a parameter
+/// \brief Collection of parameter declarations.
 message ParameterDeclarations
 {
-  /// \brief Parameter declarations;
+  /// \brief Parameter declarations.
   repeated ParameterDeclaration parameter_declarations = 1;
 };

--- a/proto/ignition/msgs/parameter_name.proto
+++ b/proto/ignition/msgs/parameter_name.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2022 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,10 @@ syntax = "proto3";
 package ignition.msgs;
 option java_package = "com.ignition.msgs";
 
-/// \brief Parameter name
+/// \brief Parameter name, used as a request to get a parameter.
 message ParameterName
 {
-  /// \brief Parameter name;
-  // TODO(ivanpauno: Maybe use `stringmsg.proto` instead (?).
+  /// \brief Parameter name.
+  // TODO(ivanpauno): Maybe use `stringmsg.proto` instead (?).
   string name = 1;
 };

--- a/proto/ignition/msgs/parameter_name.proto
+++ b/proto/ignition/msgs/parameter_name.proto
@@ -20,20 +20,10 @@ syntax = "proto3";
 package ignition.msgs;
 option java_package = "com.ignition.msgs";
 
-import "ignition/msgs/parameter.proto";
-
-/// \brief Representation of a parameter declaration
-message ParameterDeclaration
+/// \brief Parameter name
+message ParameterName
 {
-  /// \brief Parameter name.
+  /// \brief Parameter name;
+  // TODO(ivanpauno: Maybe use `stringmsg.proto` instead (?).
   string name = 1;
-
-  /// \brief Parameter type, i.e. the component type.
-  string type = 2;
-
-  /// \brief Associated component id.
-  uint64 component_id = 3;
-
-  /// \brief Associated component type id.
-  uint64 component_type_id = 4;
 };

--- a/proto/ignition/msgs/parameter_value.proto
+++ b/proto/ignition/msgs/parameter_value.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2022 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ syntax = "proto3";
 package ignition.msgs;
 option java_package = "com.ignition.msgs";
 
-/// \brief Representation of a parameter value
+/// \brief Representation of a parameter value, used as a response to get a parameter.
 message ParameterValue
 {
-  /// \brief Component type name;
+  /// \brief Parameter type, i.e. the associated protobuf type.
   string type = 2;
 
-  /// \brief Serialized component data.
+  /// \brief Serialized protobuf message.
   bytes value = 3;
 };

--- a/proto/ignition/msgs/parameter_value.proto
+++ b/proto/ignition/msgs/parameter_value.proto
@@ -20,20 +20,12 @@ syntax = "proto3";
 package ignition.msgs;
 option java_package = "com.ignition.msgs";
 
-import "ignition/msgs/parameter.proto";
-
-/// \brief Representation of a parameter declaration
-message ParameterDeclaration
+/// \brief Representation of a parameter value
+message ParameterValue
 {
-  /// \brief Parameter name.
-  string name = 1;
-
-  /// \brief Parameter type, i.e. the component type.
+  /// \brief Component type name;
   string type = 2;
 
-  /// \brief Associated component id.
-  uint64 component_id = 3;
-
-  /// \brief Associated component type id.
-  uint64 component_type_id = 4;
+  /// \brief Serialized component data.
+  bytes value = 3;
 };


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
Add message definitions to be used by the parameter system in the ignition-gazebo.

I think I have not named the messages correctly, I'll rename later.
My proposed renaming is:

- `ParameterDeclarations` -> `ParametersDeclarations`
- `ParameterName` -> `ParameterGetRequest`
- `ParameterValue` -> `ParameterGetResponse`
- `Parameter` -> `ParameterSetRequest`

The last three is to make it more obvious how they are being used in services.

The demo of how to use parameters in the wheel slip system is in https://github.com/ignitionrobotics/ign-msgs/tree/ivanpauno/parameters-impl-draft-wheel-slip-demo.

## Test it
<!--Explain how reviewers can test this new feature manually.-->
I'll include instructions of how to test in the ignition gazebo PR.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.