### PR TITLE
Added continuous joint type

### DIFF
--- a/proto/ignition/msgs/joint.proto
+++ b/proto/ignition/msgs/joint.proto
@@ -57,6 +57,7 @@ message Joint
     SCREW     = 5;
     GEARBOX   = 6;
     FIXED     = 7;
+    CONTINUOUS = 8;
   }
 
   /// \brief Optional header data

--- a/src/Utility.cc
+++ b/src/Utility.cc
@@ -567,6 +567,10 @@ namespace ignition
       {
         result = msgs::Joint::FIXED;
       }
+      else if (_str == "continuous")
+      {
+        result = msgs::Joint::CONTINUOUS;
+      }
       else
       {
         std::cerr << "Unrecognized JointType ["
@@ -621,6 +625,11 @@ namespace ignition
         case msgs::Joint::FIXED:
         {
           result = "fixed";
+          break;
+        }
+        case msgs::Joint::CONTINUOUS:
+        {
+          result = "continuous";
           break;
         }
         default:

--- a/src/Utility_TEST.cc
+++ b/src/Utility_TEST.cc
@@ -599,6 +599,7 @@ TEST(MsgsTest, ConvertMsgsJointTypeToString)
   CompareMsgsJointTypeToString(msgs::Joint::SCREW);
   CompareMsgsJointTypeToString(msgs::Joint::GEARBOX);
   CompareMsgsJointTypeToString(msgs::Joint::FIXED);
+  CompareMsgsJointTypeToString(msgs::Joint::CONTINUOUS);
 
   EXPECT_EQ(msgs::ConvertJointType("bad type"), msgs::Joint::REVOLUTE);
   EXPECT_EQ(msgs::ConvertJointType(msgs::Joint::Type(100)), "unknown");


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

SDF has a `continuous` joint type, which was missing in the joint message.
 
## Test it

Run the tests

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
