### PR TITLE
Added field to light.proto to define if a light is on or off

### DIFF
--- a/proto/ignition/msgs/light.proto
+++ b/proto/ignition/msgs/light.proto
@@ -64,4 +64,8 @@ message Light
 
   /// \brief light intensity
   float intensity               = 18;
+
+  /// \brief is the light on or off
+  /// true is on, otherwise is off
+  bool is_light_on              = 19;
 }


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🎉 New feature

Related with : 
 - https://github.com/ignitionrobotics/ign-gazebo/pull/1343
 - https://github.com/ignitionrobotics/sdformat/pull/851

## Summary

Added field to `light.proto` to define if a light is on or off

## Test it

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
