### PR TITLE
Pose, twist and odometry with covariance msgs

### DIFF
--- a/proto/ignition/msgs/odometry_with_covariance.proto
+++ b/proto/ignition/msgs/odometry_with_covariance.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2022 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/ignition/msgs/odometry_with_covariance.proto
+++ b/proto/ignition/msgs/odometry_with_covariance.proto
@@ -29,12 +29,12 @@ import "ignition/msgs/twist_with_covariance.proto";
 
 message OdometryWithCovariance
 {
-  /// \brief Optional header data
+  /// \brief Optional header data.
   Header header                             = 1;
 
   /// \brief Estimated pose.
   PoseWithCovariance pose_with_covariance   = 2;
 
-  /// \brief Estimated velocity.
+  /// \brief Estimated linear and angular velocities.
   TwistWithCovariance twist_with_covariance = 3;
 }

--- a/proto/ignition/msgs/odometry_with_covariance.proto
+++ b/proto/ignition/msgs/odometry_with_covariance.proto
@@ -30,11 +30,11 @@ import "ignition/msgs/twist_with_covariance.proto";
 message OdometryWithCovariance
 {
   /// \brief Optional header data
-  Header header  = 1;
+  Header header                             = 1;
 
   /// \brief Estimated pose.
-  PoseWithCovariance pose_with_covariance      = 2;
+  PoseWithCovariance pose_with_covariance   = 2;
 
   /// \brief Estimated velocity.
-  TwistWithCovariance twist_with_covariance    = 3;
+  TwistWithCovariance twist_with_covariance = 3;
 }

--- a/proto/ignition/msgs/odometry_with_covariance.proto
+++ b/proto/ignition/msgs/odometry_with_covariance.proto
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+syntax = "proto3";
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+option java_outer_classname = "OdometryWithCovarianceProtos";
+
+/// \ingroup ignition.msgs
+/// \interface OdometryWithCovariance
+/// \brief Message for odometry with covariance
+
+import "ignition/msgs/header.proto";
+import "ignition/msgs/pose_with_covariance.proto";
+import "ignition/msgs/twist_with_covariance.proto";
+
+message OdometryWithCovariance
+{
+  /// \brief Optional header data
+  Header header  = 1;
+
+  /// \brief Estimated pose.
+  PoseWithCovariance pose_with_covariance      = 2;
+
+  /// \brief Estimated velocity.
+  TwistWithCovariance twist_with_covariance    = 3;
+}

--- a/proto/ignition/msgs/pose_with_covariance.proto
+++ b/proto/ignition/msgs/pose_with_covariance.proto
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+option java_outer_classname = "PoseWithCovarianceProtos";
+
+/// \ingroup ignition.msgs
+/// \interface PoseWithCovariance
+/// \brief Message with pose and a covariance matrix
+
+import "ignition/msgs/float_v.proto";
+import "ignition/msgs/pose.proto";
+
+message PoseWithCovariance
+{
+  /// \brief Pose message.
+  Pose pose          = 1;
+
+  /// \brief Row-major representation of the 6x6 covariance matrix
+  /// The orientation parameters use a fixed-axis representation.
+  /// In order, the parameters are:
+  /// (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)
+  Float_V covariance          = 2;
+}

--- a/proto/ignition/msgs/pose_with_covariance.proto
+++ b/proto/ignition/msgs/pose_with_covariance.proto
@@ -36,5 +36,5 @@ message PoseWithCovariance
   /// The orientation parameters use a fixed-axis representation.
   /// In order, the parameters are:
   /// (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)
-  Float_V covariance          = 2;
+  Float_V covariance = 2;
 }

--- a/proto/ignition/msgs/twist.proto
+++ b/proto/ignition/msgs/twist.proto
@@ -32,7 +32,7 @@ message Twist
   /// \brief Optional header data.
   Header header          = 1;
 
-  /// \brief Lnear velocity in 3d space.
+  /// \brief Linear velocity in 3d space.
   Vector3d linear        = 2;
 
   /// \brief Angular velocity in 3d space.

--- a/proto/ignition/msgs/twist_with_covariance.proto
+++ b/proto/ignition/msgs/twist_with_covariance.proto
@@ -30,11 +30,11 @@ import "ignition/msgs/twist.proto";
 message TwistWithCovariance
 {
   /// \brief Twist message.
-  Twist twist          = 1;
+  Twist twist        = 1;
 
   /// \brief Row-major representation of the 6x6 covariance matrix
   /// The orientation parameters use a fixed-axis representation.
   /// In order, the parameters are:
   /// (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)
-  Float_V covariance          = 2;
+  Float_V covariance = 2;
 }

--- a/proto/ignition/msgs/twist_with_covariance.proto
+++ b/proto/ignition/msgs/twist_with_covariance.proto
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+option java_outer_classname = "TwistWithCovarianceProtos";
+
+/// \ingroup ignition.msgs
+/// \interface TwistWithCovariance
+/// \brief Message with twist and a covariance matrix
+
+import "ignition/msgs/float_v.proto";
+import "ignition/msgs/twist.proto";
+
+message TwistWithCovariance
+{
+  /// \brief Twist message.
+  Twist twist          = 1;
+
+  /// \brief Row-major representation of the 6x6 covariance matrix
+  /// The orientation parameters use a fixed-axis representation.
+  /// In order, the parameters are:
+  /// (x, y, z, rotation about X axis, rotation about Y axis, rotation about Z axis)
+  Float_V covariance          = 2;
+}


### PR DESCRIPTION
Signed-off-by: Aditya <aditya050995@gmail.com>

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

# 🎉 New feature

## Summary
This PR adds 2 new message types : ``TwistWithCovariance`` and ``PoseWithCovariance`` which have covariance matrices along with the original twist / pose message. This type was available in ``geometry_msgs/*WithCovariance`` and was used in ``gazebo_ros_pkgs`` in cases where the poses have noise associated with them.

Also fixes a minor typo in ``twist.proto``

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
