### PR TITLE
backport NavSat message for bridge compatibility

### DIFF
--- a/proto/ignition/msgs/navsat.proto
+++ b/proto/ignition/msgs/navsat.proto
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package ignition.msgs;
+option java_package = "com.ignition.msgs";
+option java_outer_classname = "NavSatProtos";
+
+/// \ingroup ignition.msgs
+/// \interface NavSat
+/// \brief Data from a NavSat sensor
+/// This replaces the GPS message.
+
+import "ignition/msgs/header.proto";
+
+message NavSat
+{
+  /// \brief Optional header data
+  Header header                = 1;
+
+  /// \brief Latitude in degrees
+  double latitude_deg          = 2;
+
+  /// \brief Longitude in degrees
+  double longitude_deg         = 3;
+
+  /// \brief Altitude in meters
+  double altitude              = 4;
+
+  /// \brief East velocity in the ENU frame, in m / s
+  double velocity_east         = 5;
+
+  /// \brief North velocity in the ENU frame, in m / s
+  double velocity_north        = 6;
+
+  /// \brief Up velocity in the ENU frame, in m / s
+  double velocity_up           = 7;
+
+  /// \brief ID of reference frame
+  string frame_id              = 8;
+}


### PR DESCRIPTION
Signed-off-by: Tyler Howell <76003804+TyHowellWork@users.noreply.github.com>

# 🎉 New feature

## Summary
Backports NavSat message for compatibility with ros_ign Melodic NavSat bridge, [PR](https://github.com/ignitionrobotics/ros_ign/pull/224).

## Test it
NavSat sensor not added, just message definition - no new capability added.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.