### PR TITLE
Generator: Add missing std namespace to string arguments for Protobuf 3.20 compatibility

### DIFF
--- a/src/Generator.cc
+++ b/src/Generator.cc
@@ -67,7 +67,7 @@ Generator::~Generator()
 
 /////////////////////////////////////////////////
 bool Generator::Generate(const FileDescriptor *_file,
-                               const string &/*_parameter*/,
+                               const std::string &/*_parameter*/,
                                OutputDirectory *_generatorContext,
                                std::string * /*_error*/) const
 {

--- a/src/Generator.hh
+++ b/src/Generator.hh
@@ -44,9 +44,9 @@ class Generator : public CodeGenerator
   /// \param[in] _generatorContext Output directory.
   /// \param[in] _error Unused string value
   public: virtual bool Generate(const FileDescriptor *_file,
-              const string &_parameter,
+              const std::string &_parameter,
               OutputDirectory *_generatorContext,
-              string *_error) const;
+              std::string *_error) const;
 
   // private: GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(Generator);
 };


### PR DESCRIPTION
# 🦟 Bug fix

Fixes the following error that occurs when building the library against Protobuf 3.20 : 
~~~
[  0%] Building CXX object src/CMakeFiles/ign_msgs_gen.dir/Generator.cc.o
In file included from /home/conda/feedstock_root/build_artifacts/libignition-msgs5_1649622632208/work/src/Generator.cc:40:
/home/conda/feedstock_root/build_artifacts/libignition-msgs5_1649622632208/work/src/Generator.hh:47:21: error: 'string' does not name a type; did you mean 'strings'?
   47 |               const string &_parameter,
      |                     ^~~~~~
      |                     strings
/home/conda/feedstock_root/build_artifacts/libignition-msgs5_1649622632208/work/src/Generator.hh:49:15: error: 'string' has not been declared
   49 |               string *_error) const;
      |               ^~~~~~
/home/conda/feedstock_root/build_artifacts/libignition-msgs5_1649622632208/work/src/Generator.cc:70:38: error: 'string' does not name a type; did you mean 'strings'?
   70 |                                const string &/*_parameter*/,
      |                                      ^~~~~~
      |                                      strings

~~~

This was detected in https://github.com/conda-forge/libignition-msgs1-feedstock/pull/73 .

## Summary
Several uses of `string`  were missing `std::`, probably with protobuf<3.20 everything was working just by chance.

## Checklist
- [ ] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

