### PR TITLE
Remove SuppressWarning from msgs.hh to fix warnings

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -7,7 +7,8 @@ release will remove the deprecated code.
 
 ## Ignition Msgs 8.X to 9.X
 
-1. **SuppressWarnings** is deprecated, use ign-utils instead.
+1. **SuppressWarnings.hh** is deprecated and isn't part of `msgs.hh` anymore.
+   Use ign-utils instead.
 
 ## Ignition Msgs 8.1 to 8.2
 

--- a/include/ignition/msgs/CMakeLists.txt
+++ b/include/ignition/msgs/CMakeLists.txt
@@ -1,3 +1,6 @@
 ign_install_all_headers(
   GENERATED_HEADERS
-    MessageTypes.hh)
+    MessageTypes.hh
+  INSTALL_BUT_DONT_INCLUDE
+    SuppressWarning.hh
+)

--- a/include/ignition/msgs/CMakeLists.txt
+++ b/include/ignition/msgs/CMakeLists.txt
@@ -1,6 +1,12 @@
 ign_install_all_headers(
   GENERATED_HEADERS
     MessageTypes.hh
-  INSTALL_BUT_DONT_INCLUDE
+  EXCLUDE_FILES
     SuppressWarning.hh
+)
+
+install(
+  FILES
+    SuppressWarning.h
+  DESTINATION ${IGN_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR}
 )

--- a/include/ignition/msgs/CMakeLists.txt
+++ b/include/ignition/msgs/CMakeLists.txt
@@ -7,6 +7,6 @@ ign_install_all_headers(
 
 install(
   FILES
-    SuppressWarning.h
+    SuppressWarning.hh
   DESTINATION ${IGN_INCLUDE_INSTALL_DIR_FULL}/${PROJECT_INCLUDE_DIR}
 )


### PR DESCRIPTION
# 🦟 Bug fix

* Fixes a bunch of warnings introduced in https://github.com/ignitionrobotics/ign-msgs/pull/243
* ~~Requires https://github.com/ignitionrobotics/ign-cmake/pull/234~~

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Prevent the deprecated header from being included by anyone who includes `msgs.hh`.

This is technically not a soft tick, because someone relying on the suppression macros from `msgs.hh` would be broken, but I think there's probably zero people doing this.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
