### PR TITLE
Fix compatibility with protobuf v30 (cpp 6.30.0)

### DIFF
--- a/src/Generator.cc
+++ b/src/Generator.cc
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -71,12 +72,12 @@ bool Generator::Generate(const FileDescriptor *_file,
                                OutputDirectory *_generatorContext,
                                std::string * /*_error*/) const
 {
-  std::string headerFilename = _file->name();
+  std::string headerFilename{_file->name()};
   std::string delim = ".proto";
   size_t pos = headerFilename.rfind(delim);
   headerFilename.replace(pos, delim.size(), ".pb.h");
 
-  std::string sourceFilename = _file->name();
+  std::string sourceFilename{_file->name()};
   pos = sourceFilename.rfind(delim);
   sourceFilename.replace(pos, delim.size(), ".pb.cc");
 
@@ -144,10 +145,12 @@ bool Generator::Generate(const FileDescriptor *_file,
     // Call the IGN_REGISTER_STATIC_MSG macro for each message
     for (auto i = 0; i < _file->message_type_count(); ++i)
     {
-      std::string factory = "IGN_REGISTER_STATIC_MSG(\"ign_msgs.";
-      factory += _file->message_type(i)->name() + "\", " +
-        _file->message_type(i)->name() +")\n";
-      printer.Print(factory.c_str(), "name", "includes");
+      std::stringstream factory;
+      factory << "IGN_REGISTER_STATIC_MSG(\"ign_msgs."
+              << _file->message_type(i)->name() << "\", "
+              << _file->message_type(i)->name() << ")\n";
+      std::string factoryStr = factory.str();
+      printer.Print(factoryStr.c_str(), "name", "includes");
     }
   }
 
@@ -161,26 +164,29 @@ bool Generator::Generate(const FileDescriptor *_file,
     for (auto i = 0; i < _file->message_type_count(); ++i)
     {
       // Define std::unique_ptr types for our messages
-      std::string ptrTypes = "typedef std::unique_ptr<"
-        + _file->message_type(i)->name() + "> "
-        + _file->message_type(i)->name() + "UniquePtr;\n";
+      std::stringstream ptrTypes;
+
+      ptrTypes << "typedef std::unique_ptr<"
+               << _file->message_type(i)->name() << "> "
+               << _file->message_type(i)->name() << "UniquePtr;\n";
 
       // Define const std::unique_ptr types for our messages
-      ptrTypes += "typedef std::unique_ptr<const "
-        + _file->message_type(i)->name() + "> Const"
-        + _file->message_type(i)->name() + "UniquePtr;\n";
+      ptrTypes << "typedef std::unique_ptr<const "
+               << _file->message_type(i)->name() << "> Const"
+               << _file->message_type(i)->name() << "UniquePtr;\n";
 
       // Define std::shared_ptr types for our messages
-      ptrTypes += "typedef std::shared_ptr<"
-        + _file->message_type(i)->name() + "> "
-        + _file->message_type(i)->name() + "SharedPtr;\n";
+      ptrTypes << "typedef std::shared_ptr<"
+               << _file->message_type(i)->name() << "> "
+               << _file->message_type(i)->name() << "SharedPtr;\n";
 
       // Define const std::shared_ptr types for our messages
-      ptrTypes += "typedef std::shared_ptr<const "
-        + _file->message_type(i)->name() + "> Const"
-        + _file->message_type(i)->name() + "SharedPtr;\n";
+      ptrTypes << "typedef std::shared_ptr<const "
+               << _file->message_type(i)->name() << "> Const"
+               << _file->message_type(i)->name() << "SharedPtr;\n";
 
-      printer.Print(ptrTypes.c_str(), "name", "namespace_scope");
+      std::string ptrTypesStr = ptrTypes.str();
+      printer.Print(ptrTypesStr.c_str(), "name", "namespace_scope");
     }
   }
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compilation with protobuf v30. This adapts https://github.com/gazebosim/gz-msgs/pull/499 to work in the `ign-msg8` branch.

## Summary

This resolves some compatibility issues with protobuf v30 (cpp 6.30.0) and later due to protobuf moving from string to string_view in some of the API.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: C

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

