### PR TITLE
Suggestion for new dynamic detachable joint plugin

### DIFF
--- a/proto/gz/msgs/dynamic_detachable_joint.proto
+++ b/proto/gz/msgs/dynamic_detachable_joint.proto
@@ -21,7 +21,6 @@ syntax = "proto3";
 package gz.msgs;
 option java_package = "com.gz.msgs";
 option java_outer_classname = "DynamicDetachableJointProtos";
-import "gz/msgs/header.proto";
 
 /// \ingroup gz.msgs
 /// \interface AttachDetachRequest
@@ -41,15 +40,12 @@ message AttachDetachRequest
     DETACH = 2;
   }
 
-  /// \brief Optional header data
-  Header header = 1;
-
   /// \brief Name of the child model.
-  string child_model_name = 2;
+  string child_model_name = 1;
 
   /// \brief Name of the child link.
-  string child_link_name = 3;
+  string child_link_name = 2;
 
   /// \brief Command to attach or detach.
-  Command command = 4;
+  Command command = 3;
 }

--- a/proto/gz/msgs/dynamic_detachable_joint.proto
+++ b/proto/gz/msgs/dynamic_detachable_joint.proto
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Contributor: Adarsh Karan K P
+// Neobotix GmbH
+
+syntax = "proto3";
+package gz.msgs;
+option java_package = "com.gz.msgs";
+option java_outer_classname = "DynamicDetachableJointProtos";
+import "gz/msgs/header.proto";
+
+/// \ingroup gz.msgs
+/// \interface AttachDetachRequest
+/// \brief Request to attach or detach a runtime detachable joint.
+message AttachDetachRequest
+{
+  /// \brief Command to apply.
+  enum Command
+  {
+    /// \brief Invalid command.
+    COMMAND_UNSPECIFIED = 0;
+
+    /// \brief Attach the requested child link.
+    ATTACH = 1;
+
+    /// \brief Detach the requested child link.
+    DETACH = 2;
+  }
+
+  /// \brief Optional header data
+  Header header = 1;
+
+  /// \brief Name of the child model.
+  string child_model_name = 2;
+
+  /// \brief Name of the child link.
+  string child_link_name = 3;
+
+  /// \brief Command to attach or detach.
+  Command command = 4;
+}

--- a/proto/gz/msgs/result.proto
+++ b/proto/gz/msgs/result.proto
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Contributor: Adarsh Karan K P
+// Neobotix GmbH
+
+syntax = "proto3";
+package gz.msgs;
+option java_package = "com.gz.msgs";
+option java_outer_classname = "ResultProtos";
+
+/// \ingroup gz.msgs
+/// \interface Result
+/// \brief Generic result message for service responses.
+message Result
+{
+  /// \brief 0 if the operation was successful.
+  int32 error_code = 1;
+
+  /// \brief Additional message or error description.
+  string message = 2;
+}


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🎉 New feature

Closes -

## Summary
Added a new protobuf defn to support the `dynamic_detachable_joint` system discussed in Issue https://github.com/gazebosim/gz-sim/issues/2362

NOTE: the `header` data part hasn't been implemented yet 

## Test it

Adding the plugin to robot model URDF/SDF
```
    <gazebo>
      <plugin filename="gz-sim-dynamic-detachable-joint-system"
            name="gz::sim::systems::DynamicDetachableJoint">
        <parent_link>robotiq_85_left_finger_tip_link</parent_link>
        <service_name>/payload/attach_detach</service_name>
        <output_topic>/child_state</output_topic>
        <attach_distance>0.25</attach_distance>
      </plugin>
    </gazebo>

```

GZ Service call command
```
# Attach
gz service -s /payload/attach_detach \
    --reqtype gz.msgs.AttachDetachRequest \
    --reptype gz.msgs.AttachDetachResponse \
    --timeout 3000 \
    --req 'child_model_name: "cube", 
           child_link_name: "link", 
           command: "attach"'

# Detach
gz service -s /payload/attach_detach \
    --reqtype gz.msgs.AttachDetachRequest \
    --reptype gz.msgs.AttachDetachResponse \
    --timeout 2000 \
    --req 'child_model_name: "cube", 
           child_link_name: "link", 
           command: "detach"'
```
ROS2 Service call command
```
# Attach
ros2 service call /payload/attach_detach \
    ros_gz_interfaces/srv/AttachDetach \
    "{child_model_name: 'cube', 
      child_link_name: 'link', 
      command: 'attach'}"

# Detach  
ros2 service call /payload/attach_detach \
    ros_gz_interfaces/srv/AttachDetach \
    "{child_model_name: 'cube', 
      child_link_name: 'link', 
      command: 'detach'}"
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.) 

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

