### PR TITLE
Prepare for 12.0.0~pre2 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(gz-cmake REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre1
+gz_configure_project(VERSION_SUFFIX pre2
   CONFIG_EXTRAS "gz-msgs-extras.cmake.in")
 
 #============================================================================

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,16 @@
 
 1. **Baseline:** this includes all changes from 11.1.0 and earlier.
 
+1. Use uint64 type for component IDs
+    * [Pull request #529](https://github.com/gazebosim/gz-msgs/pull/529)
+
+1. Tutorial updates:
+    * [Pull request #532](https://github.com/gazebosim/gz-msgs/pull/532)
+    * [Pull request #531](https://github.com/gazebosim/gz-msgs/pull/531)
+    * [Pull request #494](https://github.com/gazebosim/gz-msgs/pull/494)
+
 1. Bazel updates
+    * [Pull request #530](https://github.com/gazebosim/gz-msgs/pull/530)
     * [Pull request #521](https://github.com/gazebosim/gz-msgs/pull/521)
     * [Pull request #519](https://github.com/gazebosim/gz-msgs/pull/519)
     * [Pull request #514](https://github.com/gazebosim/gz-msgs/pull/514)
@@ -31,9 +40,6 @@
 
 1. Bump gz-cmake and others in jetty
     * [Pull request #506](https://github.com/gazebosim/gz-msgs/pull/506)
-
-1. docs: fix typo in tutorials/message_generation.md
-    * [Pull request #494](https://github.com/gazebosim/gz-msgs/pull/494)
 
 1. Remove deprecations: tock
     * [Pull request #476](https://github.com/gazebosim/gz-msgs/pull/476)


### PR DESCRIPTION

# 🎈 Release

Preparation for 12.0.0~pre2 release.

Comparison to 12.0.0~pre1: https://github.com/gazebosim/gz-msgs/compare/gz-msgs12_12.0.0-pre1...gz-msgs12

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
