### PR TITLE
Manual forward port of: Bazel updates (#537)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,6 @@
-load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_file", "gz_configure_header", "gz_export_header")
+load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_file", "gz_configure_header", "gz_export_header", "gz_include_header")
 load("@rules_license//rules:license.bzl", "license")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@rules_python//python:proto.bzl", "py_proto_library")
@@ -47,6 +49,15 @@ public_headers_no_gen = glob([
     "core/include/gz/msgs/convert/*.hh",
     "core/include/gz/msgs/detail/*.hh",
 ])
+
+gz_include_header(
+    name = "Include",
+    out = "include/gz/msgs.hh",
+    hdrs = public_headers_no_gen + [
+        "include/gz/msgs/Export.hh",
+        "include/gz/msgs/config.hh",
+    ],
+)
 
 protos = glob(["proto/gz/msgs/*.proto"])
 
@@ -113,6 +124,7 @@ public_headers = public_headers_no_gen + [
     "include/gz/msgs/config.hh",
     "include/gz/msgs/Export.hh",
     "include/gz/msgs/MessageTypes.hh",
+    "include/gz/msgs.hh",
 ]
 
 cc_library(
@@ -146,89 +158,6 @@ cc_library(
         "@tinyxml2",
     ],
 )
-
-# test_sources = glob(
-#     include = ["src/*_TEST.cc"],
-#     exclude = [],
-# )
-
-# [cc_test(
-#     name = src.replace("/", "_").replace(".cc", "").replace("src_", ""),
-#     srcs = [src],
-#     data = [
-#         "test/desc",
-#     ],
-#     defines = [
-#         'GZ_MSGS_TEST_PATH=\\"msgs/test\\"',
-#     ],
-#     deps = [
-#         ":msgs",
-#         GZ_ROOT + "common/testing",
-#         "@gtest",
-#         "@gtest//:gtest_main",
-#     ],
-# ) for src in test_sources]
-
-cc_test(
-    name = "INTEGRATION_headers",
-    srcs = ["test/integration/headers.cc"],
-    deps = [
-        ":gzmsgs_cc_proto",
-        "@googletest//:gtest",
-        "@googletest//:gtest_main",
-    ],
-)
-
-cc_test(
-    name = "INTEGRATION_image_msg",
-    srcs = ["test/integration/image_msg.cc"],
-    deps = [
-        ":gzmsgs_cc_proto",
-        "@googletest//:gtest",
-        "@googletest//:gtest_main",
-    ],
-)
-
-# cc_test(
-#     name = "INTEGRATION_Utility",
-#     srcs = ["test/integration/Utility_TEST.cc"],
-#     deps = [
-#         ":msgs",
-#         GZ_ROOT + "common/testing",
-#         "@gtest",
-#         "@gtest//:gtest_main",
-#     ],
-# )
-
-# cc_test(
-#     name = "INTEGRATION_Factory",
-#     srcs = ["test/integration/Factory_TEST.cc"],
-#     data = ["test/desc/stringmsg.desc"],
-#     defines = [
-#         'GZ_MSGS_TEST_PATH=\\"msgs/test\\"',
-#     ],
-#     deps = [
-#         ":msgs",
-#         GZ_ROOT + "common/testing",
-#         "@gtest",
-#         "@gtest//:gtest_main",
-#     ],
-# )
-
-# cc_test(
-#     name = "INTEGRATION_descriptors",
-#     srcs = ["test/integration/descriptors.cc"],
-#     data = ["test/desc"],
-#     defines = [
-#         'GZ_MSGS_TEST_PATH=\\"msgs/test\\"',
-#     ],
-#     deps = [
-#         ":msgs",
-#         GZ_ROOT + "common/testing",
-#         "@gtest",
-#         "@gtest//:gtest_main",
-#     ],
-# )
 
 gz_configure_file(
     name = "msgs_yaml",
@@ -265,4 +194,20 @@ cc_binary(
         "@gz-utils//cli:GzFormatter",
         "@gz-utils//cli:cli11",
     ],
+)
+
+buildifier(
+    name = "buildifier.fix",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "fix",
+    mode = "fix",
+)
+
+buildifier_test(
+    name = "buildifier.test",
+    exclude_patterns = ["./.git/*"],
+    lint_mode = "warn",
+    mode = "diff",
+    no_sandbox = True,
+    workspace = "//:MODULE.bazel",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,21 +1,24 @@
-## MODULE.bazel
 module(
     name = "gz-msgs",
-    repo_name = "org_gazebosim_gz-msgs",
+    compatibility_level = 11,
 )
 
-bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.1")
+bazel_dep(name = "googletest", version = "1.15.2")
 bazel_dep(name = "protobuf", version = "30.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_cc", version = "0.2.14")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")
-bazel_dep(name = "rules_python", version = "0.36.0")
+bazel_dep(name = "rules_python", version = "1.0.0")
 bazel_dep(name = "tinyxml2", version = "10.0.0")
 
 # Gazebo Dependencies
-bazel_dep(name = "rules_gazebo", version = "0.0.2")
-bazel_dep(name = "gz-math")
-bazel_dep(name = "gz-utils")
+bazel_dep(name = "rules_gazebo", version = "0.0.6")
+bazel_dep(name = "gz-math", version = "9.0.0")
+bazel_dep(name = "gz-utils", version = "4.0.0")
 
+# Override Gz deps to be pulled from the `main` branches so that CI uses deps
+# from HEAD on `main`.
 archive_override(
     module_name = "gz-math",
     strip_prefix = "gz-math-main",

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+package(
+    default_applicable_licenses = ["//:license"],
+    features = [
+        "layering_check",
+        "parse_headers",
+    ],
+)
+
+integration_tests = glob(
+    include = ["integration/*.cc"],
+    exclude = ["integration/gz_TEST.cc"],
+)
+
+[cc_test(
+    name = "INTEGRATION_%s" % test.replace("integration/", "").replace("/", "_").replace(".cc", ""),
+    srcs = ["%s" % test],
+    data = glob(["desc/**"]),
+    defines = ['GZ_MSGS_TEST_PATH=\\"test\\"'],
+    deps = [
+        "//:gz-msgs",
+        "//:gzmsgs_cc_proto",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+        "@gz-math",
+    ],
+) for test in integration_tests]


### PR DESCRIPTION
The change had to be amended to apply it on main. Specifically, the repo `archive_override`s in MODULE.bazel for gz deps was removed in that PR on the Jetty branch, but we want to preserve it on main to ensure CI uses gz deps from HEAD.

-- Original PR description

- Few small fixes in MODULE.bazel as pre-work to add automation to push new releases to BCR:
    - Drop `repo_name`, which removes the need to patch MODULE.bazel when pushing a release to BCR. `repo_name` is not a required field and can be added on the client side during import if needed to disambiguate packages.
    - Add `compatibility_level` to match [what is set in BCR](https://github.com/bazelbuild/bazel-central-registry/blob/928128b1c60e7e32d21ea8bde9fd802674eba5f3/modules/gz-msgs/12.0.0-pre1/MODULE.bazel#L5)
    - Bump `googletest` and `rules_python` to versions indicated by bazel in resolved build graph for the repo.
- Add `buildifier` linting for consistent bazel files formatting.
    - Use `cc_library` and `cc_test` from `rules_cc`, rather than native rules which are [deprecated in bazel 9](https://bazel.build/about/roadmap#migration_of_android_c_java_python_and_proto_rules). The buildifier lint target added above already enforces this.
    - Fix lint warnings for tools/gz_msgs_generate.bzl
- Move test targets to test/BUILD.bazel and use list comprehension to generate test targets.
    - While this is not standard bazel practice, this approach is adopted across the gz packages to reduce churn for external contributors who may not be familiar with bazel.
- Add lumped `msgs.hh` header for parity with cmake build.
    - Requires `rules_gazebo` to be bumped to 0.0.6.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
