### PR TITLE
[bazel/infra] Disable windows CI

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -22,3 +22,4 @@ jobs:
         [
           {"folder": ".", "bzlmodEnabled": false},
         ]
+      exclude_windows: true


### PR DESCRIPTION
# Internal tooling

Drop Windows from test matrix, since we currently don't support bazel build for Gazebo on Windows ([example build failure](https://github.com/gazebosim/gz-utils/actions/runs/20183936724/job/57950256775#step:7:49)). Note that bazel CI was previously running only on the main branch on Windows on pushes (see [action platform selection logic](https://github.com/bazel-contrib/.github/blob/v7.2.3/.github/workflows/bazel.yaml#L68)).

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.