### PR TITLE
[bazel/infra] Future-proof branch filtering in CI

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,9 +1,10 @@
 name: Bazel CI
 on:
-  push:
-    branches: [gz-msgs11, main]
   pull_request:
-    branches: [gz-msgs11, main]
+  push:
+    branches:
+      - 'gz-msgs[1-9]?[0-9]'
+      - 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
# Internal tooling

Update branch filtering to always run on pull requests and conditionally on `main` and `gz-msgs[1-9]?[0-9]` (same as cmake CI). This was already done on the gz-msgs12 branch: https://github.com/gazebosim/gz-msgs/pull/530

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.