### PR TITLE
Add CAN frame message

### DIFF
--- a/proto/gz/msgs/can_frame.proto
+++ b/proto/gz/msgs/can_frame.proto
@@ -1,20 +1,34 @@
 syntax = "proto3";
 package gz.msgs;
+option java_package = "com.gz.msgs";
+option java_outer_classname = "CanFrameProtos";
+
+/// \ingroup gz.msgs
+/// \interface CanFrame
+/// \brief A message representing an equivalent physical CAN bus message. Intended to directly map to ROS 2 can_msgs/Frame message (https://github.com/ros-industrial/ros_canopen/blob/dashing-devel/can_msgs/msg/Frame.msg)
+
 import "gz/msgs/header.proto";
 
 message CanFrame
 {
+  /// \brief Header data. Only timestamp is required
   Header header = 1;
 
+  /// \brief CAN message ID
   uint32 id = 2;
 
+  /// \brief True if this message is a Remote Transmission Request (RTR) CAN frame
   bool is_rtr = 3;
 
+  /// \brief True if this message uses an extended CAN ID
   bool is_extended = 4;
 
+  /// \brief True if this message is an error CAN frame
   bool is_error = 5;
 
+  /// \brief Length of the data field of the CAN frame (valid is 1 to 8 bytes)
   uint32 dlc = 6;
 
+  /// \brief Array of the CAN message payload. Length should match dlc field
   bytes data = 7;
 }

--- a/proto/gz/msgs/can_frame.proto
+++ b/proto/gz/msgs/can_frame.proto
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 Dataspeed Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 syntax = "proto3";
 package gz.msgs;
 option java_package = "com.gz.msgs";

--- a/proto/gz/msgs/can_frame.proto
+++ b/proto/gz/msgs/can_frame.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package gz.msgs;
+import "gz/msgs/header.proto";
+
+message CanFrame
+{
+  Header header = 1;
+
+  uint32 id = 2;
+
+  bool is_rtr = 3;
+
+  bool is_extended = 4;
+
+  bool is_error = 5;
+
+  uint32 dlc = 6;
+
+  bytes data = 7;
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary
Adds a CAN message equivalent to the ROS can_msgs/Frame. Can be used to emulate the CAN interface to a robot's embedded systems.

## Test it
Build gz-msgs normally and verify that `can_frame.pb.h` is automatically generated.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

