### PR TITLE
Load always the own gz_msgs*.gz_desc first and avoid duplicates

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,6 +34,7 @@ gz_configure_header(
     name = "Config",
     src = "core/include/gz/msgs/config.hh.in",
     out = "include/gz/msgs/config.hh",
+    defines = ["GZ_MSGS_DESC_FILENAME=gz-msgs.gz_desc"],
     package_xml = "package.xml",
 )
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -63,18 +63,20 @@ gz_msgs_generate_messages_impl(
     msgs_python
 )
 
+set(GZ_MSGS_DESC_FILENAME "gz-msgs.gz_desc")
+
 gz_msgs_generate_desc_impl(
   PROTOC_EXEC ${${PROJECT_NAME}_PROTOC_EXECUTABLE}
   INPUT_PROTOS ${proto_files}
   PROTO_PATH ${PROJECT_SOURCE_DIR}/proto
   DEPENDENCY_DESCRIPTIONS ${depends_msgs_desc}
   OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/gz_msgs_gen
-  OUTPUT_FILENAME gz-msgs.gz_desc
+  OUTPUT_FILENAME ${GZ_MSGS_DESC_FILENAME}
 )
 
 install(FILES ${msgs_headers} DESTINATION ${GZ_INCLUDE_INSTALL_DIR_FULL}/gz/msgs)
 install(FILES ${msgs_detail_headers} DESTINATION ${GZ_INCLUDE_INSTALL_DIR_FULL}/gz/msgs/details)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/gz-msgs.gz_desc
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${GZ_MSGS_DESC_FILENAME}
   DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/gz/protos/)
 
 if (NOT GZ_PYTHON_INSTALL_PATH)
@@ -102,7 +104,7 @@ gz_create_core_library(SOURCES
   src/MessageFactory.cc
   src/DynamicFactory.cc
   ${msgs_sources}
-  gz-msgs.gz_desc
+  ${GZ_MSGS_DESC_FILENAME}
 )
 
 target_include_directories(${PROJECT_LIBRARY_TARGET_NAME} PUBLIC
@@ -113,7 +115,7 @@ set_target_properties(
     PROPERTIES
       SOVERSION ${PROJECT_VERSION_MAJOR}
       VERSION ${PROJECT_VERSION_FULL}
-      GZ_MSGS_DESC_FILE "\$\{_IMPORT_PREFIX\}/share/gz/protos/gz-msgs.gz_desc"
+      GZ_MSGS_DESC_FILE "\$\{_IMPORT_PREFIX\}/share/gz/protos/${GZ_MSGS_DESC_FILENAME}"
       )
 set_property(TARGET ${PROJECT_LIBRARY_TARGET_NAME} PROPERTY EXPORT_PROPERTIES "GZ_MSGS_DESC_FILE")
 

--- a/core/include/gz/msgs/config.hh.in
+++ b/core/include/gz/msgs/config.hh.in
@@ -32,4 +32,6 @@
 
 #define GZ_MSGS_VERSION_HEADER "Gazebo Msgs, version ${PROJECT_VERSION_FULL}\nCopyright (C) 2016 Open Source Robotics Foundation.\nReleased under the Apache 2.0 License.\n\n"
 
+#define GZ_MSGS_DESC_FILENAME "${GZ_MSGS_DESC_FILENAME}"
+
 #endif

--- a/core/src/DynamicFactory.cc
+++ b/core/src/DynamicFactory.cc
@@ -27,6 +27,7 @@
 #include "DynamicFactory.hh"
 #include "gz/utils/Environment.hh"
 
+#include <gz/msgs/config.hh>
 #include <gz/msgs/InstallationDirectories.hh>
 
 namespace {
@@ -121,6 +122,12 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
     for (const google::protobuf::FileDescriptorProto &fileDescriptorProto :
          fileDescriptorSet.file())
     {
+      // Skip protos already loaded (e.g. same .gz_desc reached via
+      // both GZ_DESCRIPTOR_PATH and the global share directory).
+      if (this->pool.FindFileByName(fileDescriptorProto.name()) != nullptr) {
+        continue;
+      }
+
       if (!static_cast<bool>(this->pool.BuildFile(fileDescriptorProto)))
       {
         std::cerr << "DynamicFactory(). Unable to place descriptors from ["
@@ -141,8 +148,20 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
     }
     else
     {
+      // Default to loading the descriptor file for this gz-msgs major version if it exists
+      const std::string ownDescFile =
+        "gz-msgs" + std::to_string(GZ_MSGS_MAJOR_VERSION) + ".gz_desc";
+      auto ownDescPath = std::filesystem::path(descDir) / ownDescFile;
+      if (std::filesystem::exists(ownDescPath))
+      {
+        loadDescFile(ownDescPath.string());
+      }
+
       for (auto const &dirIter : std::filesystem::directory_iterator{descDir})
       {
+        auto filename = dirIter.path().filename().string();
+        if (filename == ownDescFile)  // Skip the ownDesc already loaded
+          continue;
         loadDescFile(dirIter.path().string());
       }
     }

--- a/core/src/DynamicFactory.cc
+++ b/core/src/DynamicFactory.cc
@@ -151,7 +151,8 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
     }
     else
     {
-      // Default to loading the descriptor file for this gz-msgs major version if it exists
+      // Default to loading the descriptor file for this gz-msgs major
+      // version if it exists
       auto ownDescPath = std::filesystem::path(descDir) / ownDescFile;
       if (std::filesystem::exists(ownDescPath))
       {

--- a/core/src/DynamicFactory.cc
+++ b/core/src/DynamicFactory.cc
@@ -124,7 +124,8 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
     {
       // Skip protos already loaded (e.g. same .gz_desc reached via
       // both GZ_DESCRIPTOR_PATH and the global share directory).
-      if (this->pool.FindFileByName(fileDescriptorProto.name()) != nullptr) {
+      if (this->pool.FindFileByName(fileDescriptorProto.name()) != nullptr)
+      {
         continue;
       }
 

--- a/core/src/DynamicFactory.cc
+++ b/core/src/DynamicFactory.cc
@@ -140,6 +140,9 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
     }
   };
 
+  const std::string ownDescFile =
+    "gz-msgs" + std::to_string(GZ_MSGS_MAJOR_VERSION) + ".gz_desc";
+
   for (const std::string &descDir : descDirs)
   {
     if (!std::filesystem::is_directory(descDir))
@@ -149,8 +152,6 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
     else
     {
       // Default to loading the descriptor file for this gz-msgs major version if it exists
-      const std::string ownDescFile =
-        "gz-msgs" + std::to_string(GZ_MSGS_MAJOR_VERSION) + ".gz_desc";
       auto ownDescPath = std::filesystem::path(descDir) / ownDescFile;
       if (std::filesystem::exists(ownDescPath))
       {

--- a/core/src/DynamicFactory.cc
+++ b/core/src/DynamicFactory.cc
@@ -141,8 +141,7 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
     }
   };
 
-  const std::string ownDescFile =
-    "gz-msgs" + std::to_string(GZ_MSGS_MAJOR_VERSION) + ".gz_desc";
+  const std::string ownDescFile = GZ_MSGS_DESC_FILENAME;
 
   for (const std::string &descDir : descDirs)
   {

--- a/test/integration/descriptors.cc
+++ b/test/integration/descriptors.cc
@@ -117,7 +117,8 @@ TEST(FactoryTest, NoDuplicateDescriptors)
   ::testing::internal::CaptureStderr();
 
   // Loading the same descriptor twice must not cause protobuf errors.
-  // The second occurrence is skipped because the protos are already in the pool.
+  // The second occurrence is skipped because the protos are already in the
+  // pool.
   gz::msgs::Factory::LoadDescriptors(paths);
 
   std::string stderr_output = ::testing::internal::GetCapturedStderr();

--- a/test/integration/descriptors.cc
+++ b/test/integration/descriptors.cc
@@ -19,6 +19,8 @@
 
 #include <filesystem>
 
+#include <google/protobuf/stubs/logging.h>
+
 #include "gz/msgs/Factory.hh"
 
 static constexpr const char * kMsgsTestPath = GZ_MSGS_TEST_PATH;
@@ -92,4 +94,46 @@ TEST(FactoryTest, DynamicFactory)
   EXPECT_NE(nullptr, gz::msgs::Factory::New("testing.FooMessage"));
   EXPECT_NE(nullptr, gz::msgs::Factory::New("testing.BarMessage"));
   EXPECT_NE(nullptr, gz::msgs::Factory::New("testing.BazMessage"));
+}
+
+TEST(FactoryTest, NoDuplicateDescriptors)
+{
+  // Regression test for https://github.com/gazebosim/gz-msgs/issues/460
+  // When the same .gz_desc file is reachable via both GZ_DESCRIPTOR_PATH
+  // and the global share directory, the DynamicFactory used to print:
+  //   [libprotobuf ERROR] File already exists in database: ...
+  // The fix silently skips proto definitions already present in the pool.
+
+  std::filesystem::path test_path(kMsgsTestPath);
+  std::string path = (test_path / "desc" / "stringmsg.desc").string();
+
+#ifdef _WIN32
+  std::string paths = path + ";" + path;
+#else
+  std::string paths = path + ":" + path;
+#endif
+
+  // SetLogHandler requires a plain function pointer (no captures), so use a
+  // static flag to detect ERROR-level messages from libprotobuf during loading.
+  static bool s_protobuf_error_seen;
+  s_protobuf_error_seen = false;
+  auto * old_handler = google::protobuf::SetLogHandler(
+    [](google::protobuf::LogLevel level, const char *, int,
+       const std::string &) {
+      if (level == google::protobuf::LOGLEVEL_ERROR) {
+        s_protobuf_error_seen = true;
+      }
+    });
+
+  // Loading the same descriptor twice must not cause protobuf errors.
+  // The second occurrence is skipped because the protos are already in the pool.
+  gz::msgs::Factory::LoadDescriptors(paths);
+
+  google::protobuf::SetLogHandler(old_handler);
+
+  EXPECT_FALSE(s_protobuf_error_seen)
+    << "libprotobuf ERROR emitted during duplicate descriptor load";
+
+  // The message type must remain accessible after duplicate loading.
+  EXPECT_NE(nullptr, gz::msgs::Factory::New("example.msgs.StringMsg"));
 }

--- a/test/integration/descriptors.cc
+++ b/test/integration/descriptors.cc
@@ -19,8 +19,6 @@
 
 #include <filesystem>
 
-#include <google/protobuf/stubs/logging.h>
-
 #include "gz/msgs/Factory.hh"
 
 static constexpr const char * kMsgsTestPath = GZ_MSGS_TEST_PATH;
@@ -113,26 +111,19 @@ TEST(FactoryTest, NoDuplicateDescriptors)
   std::string paths = path + ":" + path;
 #endif
 
-  // SetLogHandler requires a plain function pointer (no captures), so use a
-  // static flag to detect ERROR-level messages from libprotobuf during loading.
-  static bool s_protobuf_error_seen;
-  s_protobuf_error_seen = false;
-  auto * old_handler = google::protobuf::SetLogHandler(
-    [](google::protobuf::LogLevel level, const char *, int,
-       const std::string &) {
-      if (level == google::protobuf::LOGLEVEL_ERROR) {
-        s_protobuf_error_seen = true;
-      }
-    });
+  // Capture stderr to detect any "already exists in database" errors from
+  // libprotobuf.  Using gtest's CaptureStderr avoids depending on the
+  // protobuf-internal SetLogHandler API, which was removed in protobuf 4.x.
+  ::testing::internal::CaptureStderr();
 
   // Loading the same descriptor twice must not cause protobuf errors.
   // The second occurrence is skipped because the protos are already in the pool.
   gz::msgs::Factory::LoadDescriptors(paths);
 
-  google::protobuf::SetLogHandler(old_handler);
-
-  EXPECT_FALSE(s_protobuf_error_seen)
-    << "libprotobuf ERROR emitted during duplicate descriptor load";
+  std::string stderr_output = ::testing::internal::GetCapturedStderr();
+  EXPECT_EQ(stderr_output.find("already exists in database"), std::string::npos)
+    << "libprotobuf ERROR emitted during duplicate descriptor load: "
+    << stderr_output;
 
   // The message type must remain accessible after duplicate loading.
   EXPECT_NE(nullptr, gz::msgs::Factory::New("example.msgs.StringMsg"));


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #460

## Summary
Seems to happen when there are two files (particularly if you two gazebo versions or using GZ_DESCRIPTOR_PATH) that loads the same defined symbols. The loaders loads all files in these directories no matter what files are: https://github.com/gazebosim/gz-msgs/blob/gz-msgs12/core/src/DynamicFactory.cc#L66-L82

When there are different versions of gz-msgs installed we probably want to load first the gz-msgs{MAJOR_VERSION}.gz_desc before others are loaded since it is probably expected by this software to use he default symbols first. Not sure if this fits 100% in all use cases.

The PR does two things:
 * Avoid loading duplicate definitions
 * Always load the own gz_msgs*.gz_desc file first

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Opus 4.6

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.