### PR TITLE
Backport "Return nullptr when message fails to populate"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,7 +195,7 @@ target_include_directories(${PROJECT_LIBRARY_TARGET_NAME}
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # Disable warning in generated *.pb.cc code
-  target_compile_options(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE -Wno-extended-offsetof)
+  target_compile_options(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE -Wno-invalid-offsetof)
 endif()
 
 target_include_directories(${PROJECT_LIBRARY_TARGET_NAME}

--- a/src/Factory.cc
+++ b/src/Factory.cc
@@ -251,7 +251,12 @@ std::unique_ptr<google::protobuf::Message> Factory::New(
   std::unique_ptr<google::protobuf::Message> msg = New(_msgType);
   if (msg)
   {
-    google::protobuf::TextFormat::ParseFromString(_args, msg.get());
+    if (!google::protobuf::TextFormat::ParseFromString(_args, msg.get()))
+    {
+      // The user-provided string was invalid,
+      // return nullptr rather than an empty message.
+      msg.reset();
+    }
   }
 
   return msg;

--- a/src/Factory_TEST.cc
+++ b/src/Factory_TEST.cc
@@ -23,13 +23,14 @@
 #include "ignition/msgs/MessageTypes.hh"
 #include "ignition/msgs/Factory.hh"
 
-using namespace ignition;
+using Factory = ignition::msgs::Factory;
+using Vector3d = ignition::msgs::Vector3d;
 
 /////////////////////////////////////////////////
 TEST(FactoryTest, Type)
 {
   std::vector<std::string> types;
-  msgs::Factory::Types(types);
+  Factory::Types(types);
   EXPECT_FALSE(types.empty());
   EXPECT_TRUE(std::find(types.begin(), types.end(),
         std::string("ign_msgs.Vector3d")) !=
@@ -39,7 +40,8 @@ TEST(FactoryTest, Type)
 /////////////////////////////////////////////////
 TEST(FactoryTest, New)
 {
-  auto msg = msgs::Factory::New<msgs::Vector3d>("ign_msgs.Vector3d");
+  // Correct call, using periods, fully qualified
+  auto msg = Factory::New<Vector3d>("ignition.msgs.Vector3d");
 
   ASSERT_TRUE(msg.get() != nullptr);
 
@@ -47,7 +49,7 @@ TEST(FactoryTest, New)
   msg->set_y(2.0);
   msg->set_z(3.0);
 
-  auto msgFilled = msgs::Factory::New<msgs::Vector3d>(
+  auto msgFilled = Factory::New<Vector3d>(
       "ign_msgs.Vector3d", "x: 1.0, y: 2.0, z: 3.0");
   ASSERT_TRUE(msgFilled.get() != nullptr);
 
@@ -55,10 +57,11 @@ TEST(FactoryTest, New)
   EXPECT_DOUBLE_EQ(msg->y(), msgFilled->y());
   EXPECT_DOUBLE_EQ(msg->z(), msgFilled->z());
 
-  msg = msgs::Factory::New<msgs::Vector3d>("ignition.msgs.Vector3d");
+  // Various other supported ways of specifying gz.msgs
+  msg = Factory::New<Vector3d>("ign_msgs.Vector3d");
   EXPECT_TRUE(msg.get() != nullptr);
 
-  msg = msgs::Factory::New<msgs::Vector3d>(".ignition.msgs.Vector3d");
+  msg = Factory::New<Vector3d>(".ignition.msgs.Vector3d");
   EXPECT_TRUE(msg.get() != nullptr);
 }
 
@@ -67,15 +70,15 @@ TEST(FactoryTest, NewDynamicFactory)
 {
   std::string paths;
 
-  auto msg = msgs::Factory::New("example.msgs.StringMsg");
+  auto msg = Factory::New("example.msgs.StringMsg");
   EXPECT_TRUE(msg.get() == nullptr);
 
   paths =
       PROJECT_SOURCE_PATH "/test/desc:"
       PROJECT_SOURCE_PATH "/test";
-  msgs::Factory::LoadDescriptors(paths);
+  Factory::LoadDescriptors(paths);
 
-  msg = msgs::Factory::New("example.msgs.StringMsg");
+  msg = Factory::New("example.msgs.StringMsg");
   EXPECT_TRUE(msg.get() != nullptr);
 }
 
@@ -83,12 +86,12 @@ TEST(FactoryTest, NewDynamicFactory)
 TEST(FactoryTest, NewAllRegisteredTypes)
 {
   std::vector<std::string> types;
-  msgs::Factory::Types(types);
+  Factory::Types(types);
   EXPECT_FALSE(types.empty());
 
   for (const auto &type : types)
   {
-    auto msg = msgs::Factory::New(type);
+    auto msg = Factory::New(type);
     ASSERT_NE(nullptr, msg.get()) << type;
   }
 }
@@ -104,7 +107,7 @@ TEST(FactoryTest, MultipleMessagesInAProto)
   };
 
   std::vector<std::string> types;
-  msgs::Factory::Types(types);
+  Factory::Types(types);
   EXPECT_FALSE(types.empty());
 
   for (auto type : typesInSameFile)
@@ -114,59 +117,59 @@ TEST(FactoryTest, MultipleMessagesInAProto)
         types.end()) << type;
 
     // Check all types can be newed
-    auto msg = msgs::Factory::New(type);
+    auto msg = Factory::New(type);
     EXPECT_NE(nullptr, msg.get()) << type;
   }
 
   // Compile-time check that pointer types exist
   {
-    msgs::SerializedEntityMapUniquePtr ptr{nullptr};
+    ignition::msgs::SerializedEntityMapUniquePtr ptr{nullptr};
     EXPECT_EQ(nullptr, ptr);
   }
   {
-    msgs::ConstSerializedEntityMapUniquePtr ptr{nullptr};
+    ignition::msgs::ConstSerializedEntityMapUniquePtr ptr{nullptr};
     EXPECT_EQ(nullptr, ptr);
   }
   {
-    msgs::SerializedEntityMapSharedPtr ptr{nullptr};
+    ignition::msgs::SerializedEntityMapSharedPtr ptr{nullptr};
     EXPECT_EQ(nullptr, ptr);
   }
   {
-    msgs::ConstSerializedEntityMapSharedPtr ptr{nullptr};
-    EXPECT_EQ(nullptr, ptr);
-  }
-
-  {
-    msgs::SerializedStateMapUniquePtr ptr{nullptr};
-    EXPECT_EQ(nullptr, ptr);
-  }
-  {
-    msgs::ConstSerializedStateMapUniquePtr ptr{nullptr};
-    EXPECT_EQ(nullptr, ptr);
-  }
-  {
-    msgs::SerializedStateMapSharedPtr ptr{nullptr};
-    EXPECT_EQ(nullptr, ptr);
-  }
-  {
-    msgs::ConstSerializedStateMapSharedPtr ptr{nullptr};
+    ignition::msgs::ConstSerializedEntityMapSharedPtr ptr{nullptr};
     EXPECT_EQ(nullptr, ptr);
   }
 
   {
-    msgs::SerializedStepMapUniquePtr ptr{nullptr};
+    ignition::msgs::SerializedStateMapUniquePtr ptr{nullptr};
     EXPECT_EQ(nullptr, ptr);
   }
   {
-    msgs::ConstSerializedStepMapUniquePtr ptr{nullptr};
+    ignition::msgs::ConstSerializedStateMapUniquePtr ptr{nullptr};
     EXPECT_EQ(nullptr, ptr);
   }
   {
-    msgs::SerializedStepMapSharedPtr ptr{nullptr};
+    ignition::msgs::SerializedStateMapSharedPtr ptr{nullptr};
     EXPECT_EQ(nullptr, ptr);
   }
   {
-    msgs::ConstSerializedStepMapSharedPtr ptr{nullptr};
+    ignition::msgs::ConstSerializedStateMapSharedPtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+
+  {
+    ignition::msgs::SerializedStepMapUniquePtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
+    ignition::msgs::ConstSerializedStepMapUniquePtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
+    ignition::msgs::SerializedStepMapSharedPtr ptr{nullptr};
+    EXPECT_EQ(nullptr, ptr);
+  }
+  {
+    ignition::msgs::ConstSerializedStepMapSharedPtr ptr{nullptr};
     EXPECT_EQ(nullptr, ptr);
   }
 }

--- a/src/Factory_TEST.cc
+++ b/src/Factory_TEST.cc
@@ -40,22 +40,9 @@ TEST(FactoryTest, Type)
 /////////////////////////////////////////////////
 TEST(FactoryTest, New)
 {
-  // Correct call, using periods, fully qualified
+  // Preferred call, using periods, fully qualified
   auto msg = Factory::New<Vector3d>("ignition.msgs.Vector3d");
-
   ASSERT_TRUE(msg.get() != nullptr);
-
-  msg->set_x(1.0);
-  msg->set_y(2.0);
-  msg->set_z(3.0);
-
-  auto msgFilled = Factory::New<Vector3d>(
-      "ign_msgs.Vector3d", "x: 1.0, y: 2.0, z: 3.0");
-  ASSERT_TRUE(msgFilled.get() != nullptr);
-
-  EXPECT_DOUBLE_EQ(msg->x(), msgFilled->x());
-  EXPECT_DOUBLE_EQ(msg->y(), msgFilled->y());
-  EXPECT_DOUBLE_EQ(msg->z(), msgFilled->z());
 
   // Various other supported ways of specifying gz.msgs
   msg = Factory::New<Vector3d>("ign_msgs.Vector3d");
@@ -63,6 +50,33 @@ TEST(FactoryTest, New)
 
   msg = Factory::New<Vector3d>(".ignition.msgs.Vector3d");
   EXPECT_TRUE(msg.get() != nullptr);
+}
+
+/////////////////////////////////////////////////
+TEST(FactoryTest, NewWithWellFormedData)
+{
+  gz::msgs::Vector3d msg;
+  msg.set_x(1.0);
+  msg.set_y(2.0);
+  msg.set_z(3.0);
+
+  auto msgFilled = Factory::New<Vector3d>(
+      "ignition.msgs.Vector3d", "x: 1.0, y: 2.0, z: 3.0");
+  ASSERT_TRUE(nullptr != msgFilled);
+
+  EXPECT_DOUBLE_EQ(msg.x(), msgFilled->x());
+  EXPECT_DOUBLE_EQ(msg.y(), msgFilled->y());
+  EXPECT_DOUBLE_EQ(msg.z(), msgFilled->z());
+}
+
+
+/////////////////////////////////////////////////
+TEST(FactoryTest, NewWithMalformedData)
+{
+  /// Passing bad data to New results in a nullptr
+  auto msgFilled = Factory::New<Vector3d>(
+      "ignition.msgs.Vector3d", "x: 1.0, y: asdf, z: 3.0");
+  ASSERT_TRUE(nullptr == msgFilled);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #577.

## Summary

This is a backport of #577, which fixed https://github.com/gazebosim/gz-transport/issues/442 in Harmonic and later. This is a behavior change, which will return `nullptr` from `Factory::New` in more cases than before.

I've also backported a portion of the changes to `Factory_TEST.cc` from #374 to make https://github.com/gazebosim/gz-msgs/commit/948313444f133874a124c62c89cbd25b5d75be8b apply a little more cleanly.

I've also fixed a clang flag that was modified on newer branches since https://github.com/gazebosim/gz-msgs/pull/339.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
