### PR TITLE
[bazel/infra] Automate publish to BCR workflow on tag push

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,13 +1,19 @@
 # Publish new releases to Bazel Central Registry.
 name: Publish to BCR
 on:
-  # For now, the workflow must be manually triggered.
+  # Manual trigger
   workflow_dispatch:
     inputs:
       tag_name:
         description: git tag being released
         required: true
         type: string
+
+  # Automated trigger on git tag push
+  push:
+    tags:
+      # Glob pattern: branch_semver-postfix
+      - 'gz-msgs[1-9]?[0-9]_[0-9]+.[0-9]+.[0-9]+*'
 jobs:
   # The publish-to-bcr reusable workflow expects the version name to be in
   # semver-(optional build metadata postfix) format, but the repo tags are in
@@ -17,23 +23,31 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       prefix: ${{ steps.extract.outputs.prefix }}
+      tag_name: ${{ steps.extract.outputs.tag_name }}
     steps:
-      - name: Extract the tag prefix from the tag name.
+      - name: Determine tag name and prefix
         id: extract
         run: |
-          branch=$(echo "${{ inputs.tag_name }}" | cut -d'_' -f1)
+          # Use input if manual, otherwise use the ref_name from the push event
+          TAG_NAME="${{ inputs.tag_name || github.ref_name }}"
+
+          # Extract prefix (everything before the underscore)
+          branch=$(echo "$TAG_NAME" | cut -d'_' -f1)
           prefix="${branch}_"
-          echo "prefix=${prefix}" | tee -a "$GITHUB_OUTPUT"
+
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+          echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
 
   publish:
     needs: extract_tag_prefix
     uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.0.0
     with:
-      tag_name: ${{ inputs.tag_name }}
+      tag_name: ${{ needs.extract_tag_prefix.outputs.tag_name }}
       # GitHub repository which is a fork of the upstream where the Pull Request will be opened.
       registry_fork: gazebo-forks/bazel-central-registry
       attest: false
       tag_prefix: ${{ needs.extract_tag_prefix.outputs.prefix }}
+      draft: false
 
     permissions:
       attestations: write


### PR DESCRIPTION
# Infra improvement

## Summary
Create BCR PRs as ready for review and automatically when a tag is pushed. Similar to https://github.com/gazebosim/gz-common/pull/786

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.