### PR TITLE
Make MessageFactory thread safe

### DIFF
--- a/core/include/gz/msgs/MessageFactory.hh
+++ b/core/include/gz/msgs/MessageFactory.hh
@@ -29,9 +29,6 @@
 #include <gz/utils/ImplPtr.hh>
 
 namespace gz::msgs {
-  /// Forward declarations
-  class DynamicFactory;
-
   // Inline bracket to help doxygen filtering.
   inline namespace GZ_MSGS_VERSION_NAMESPACE {
 
@@ -110,11 +107,8 @@ namespace gz::msgs {
     /// files. Each directory should be separated by ":".
     public: void LoadDescriptors(const std::string &_paths);
 
-    /// \brief A list of registered message types
-    private: FactoryFnCollection msgMap;
-
-    /// \brief Pointer to dynamic factory implementation
-    GZ_UTILS_UNIQUE_IMPL_PTR_FWD(gz::msgs::DynamicFactory, dynamicFactory)
+    /// \brief Private data pointer.
+    GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
   };
 }
 }  // namespace gz::msgs

--- a/core/include/gz/msgs/MessageFactory.hh
+++ b/core/include/gz/msgs/MessageFactory.hh
@@ -37,6 +37,7 @@ namespace gz::msgs {
   /// This class will also try to load all Protobuf descriptors in paths
   /// provided in LoadDescriptors as well as the GZ_DESCRIPTOR_PATH
   /// environment variable.
+  /// All member functions are thread safe.
   class GZ_MSGS_VISIBLE MessageFactory
   {
     /// \brief Base message type

--- a/core/src/DynamicFactory.hh
+++ b/core/src/DynamicFactory.hh
@@ -36,6 +36,8 @@ namespace gz::msgs {
 /// via the GZ_DESCRIPTOR_PATH environment variable. This environment
 /// variable expects paths to directories containing .desc files.
 /// Any file without the .desc or .gz_desc extension will be ignored.
+/// This class is not thread safe; MessageFactory serializes all access
+/// to it.
 class DynamicFactory
 {
   public: using Message = google::protobuf::Message;

--- a/core/src/MessageFactory.cc
+++ b/core/src/MessageFactory.cc
@@ -28,9 +28,20 @@ static constexpr const char * kGzMsgsPrefix = "gz.msgs.";
 namespace gz::msgs
 {
 
+/// \brief Private implementation of MessageFactory.
+class MessageFactory::Implementation
+{
+  /// \brief A list of registered message types.
+  public: FactoryFnCollection msgMap;
+
+  /// \brief Factory for messages built at runtime from loaded descriptors.
+  public: std::unique_ptr<gz::msgs::DynamicFactory> dynamicFactory =
+      std::make_unique<gz::msgs::DynamicFactory>();
+};
+
 /////////////////////////////////////////////////
 MessageFactory::MessageFactory():
-  dynamicFactory(gz::utils::MakeUniqueImpl<gz::msgs::DynamicFactory>())
+  dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
 {
 }
 
@@ -41,7 +52,7 @@ MessageFactory::~MessageFactory() = default;
 void MessageFactory::Register(const std::string &_msgType,
                               FactoryFn _factoryfn)
 {
-  msgMap[_msgType] = _factoryfn;
+  this->dataPtr->msgMap[_msgType] = _factoryfn;
 }
 
 /////////////////////////////////////////////////
@@ -70,24 +81,15 @@ MessageFactory::MessagePtr MessageFactory::New(
     type = _msgType;
   }
 
-  auto getMessagePtr = [this](const std::string &_type)
+  if (auto it = this->dataPtr->msgMap.find(type);
+      it != this->dataPtr->msgMap.end())
   {
-    MessageFactory::MessagePtr ret;
-    if (auto it = msgMap.find(_type); it != msgMap.end())
-    {
-      // Create a new message via FactoryFn
-      ret = it->second();
-    }
-    else
-    {
-      // Create a new message via dynamic descriptors
-      ret = dynamicFactory->New(_type);
-    }
-    return ret;
-  };
+    // Create a new message via FactoryFn
+    return it->second();
+  }
 
-  auto ret = getMessagePtr(type);
-  return ret;
+  // Create a new message via dynamic descriptors
+  return this->dataPtr->dynamicFactory->New(type);
 }
 
 /////////////////////////////////////////////////
@@ -114,15 +116,15 @@ void MessageFactory::Types(std::vector<std::string> &_types)
 
   // Add the types loaded from descriptor files
   std::vector<std::string> dynTypes;
-  this->dynamicFactory->Types(dynTypes);
+  this->dataPtr->dynamicFactory->Types(dynTypes);
 
   // Use set to remove duplicates
   std::unordered_set<std::string> typesSet(dynTypes.begin(), dynTypes.end());
 
   // Return the list of all known message types.
-  for (auto iter = msgMap.begin(); iter != msgMap.end(); ++iter)
+  for (const auto &[typeName, factoryFn] : this->dataPtr->msgMap)
   {
-    typesSet.insert(iter->first);
+    typesSet.insert(typeName);
   }
 
   std::copy(typesSet.begin(), typesSet.end(), std::back_inserter(_types));
@@ -131,7 +133,7 @@ void MessageFactory::Types(std::vector<std::string> &_types)
 /////////////////////////////////////////////////
 void MessageFactory::LoadDescriptors(const std::string &_paths)
 {
-  dynamicFactory->LoadDescriptors(_paths);
+  this->dataPtr->dynamicFactory->LoadDescriptors(_paths);
 }
 
 }  // namespace gz::msgs

--- a/core/src/MessageFactory.cc
+++ b/core/src/MessageFactory.cc
@@ -145,6 +145,7 @@ void MessageFactory::Types(std::vector<std::string> &_types)
     typesSet.insert(typeName);
   }
 
+  _types.reserve(typesSet.size());
   std::copy(typesSet.begin(), typesSet.end(), std::back_inserter(_types));
 }
 

--- a/core/src/MessageFactory.cc
+++ b/core/src/MessageFactory.cc
@@ -15,6 +15,7 @@
  *
 */
 
+#include <mutex>
 #include <unordered_set>
 
 #include <google/protobuf/text_format.h>
@@ -31,6 +32,10 @@ namespace gz::msgs
 /// \brief Private implementation of MessageFactory.
 class MessageFactory::Implementation
 {
+  /// \brief Protects every member below, as well as the dynamic factory
+  /// reached through dynamicFactory, which is not thread safe on its own.
+  public: std::mutex mutex;
+
   /// \brief A list of registered message types.
   public: FactoryFnCollection msgMap;
 
@@ -52,6 +57,7 @@ MessageFactory::~MessageFactory() = default;
 void MessageFactory::Register(const std::string &_msgType,
                               FactoryFn _factoryfn)
 {
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
   this->dataPtr->msgMap[_msgType] = _factoryfn;
 }
 
@@ -81,15 +87,25 @@ MessageFactory::MessagePtr MessageFactory::New(
     type = _msgType;
   }
 
-  if (auto it = this->dataPtr->msgMap.find(type);
-      it != this->dataPtr->msgMap.end())
+  FactoryFn factoryFn;
   {
-    // Create a new message via FactoryFn
-    return it->second();
+    std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+    if (auto it = this->dataPtr->msgMap.find(type);
+        it != this->dataPtr->msgMap.end())
+    {
+      // Copy the factory function so that it can be invoked outside the
+      // lock, allowing a factory function to call back into this class.
+      factoryFn = it->second;
+    }
+    else
+    {
+      // Create a new message via dynamic descriptors
+      return this->dataPtr->dynamicFactory->New(type);
+    }
   }
 
-  // Create a new message via dynamic descriptors
-  return this->dataPtr->dynamicFactory->New(type);
+  // Create a new message via FactoryFn
+  return factoryFn();
 }
 
 /////////////////////////////////////////////////
@@ -114,6 +130,8 @@ void MessageFactory::Types(std::vector<std::string> &_types)
 {
   _types.clear();
 
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+
   // Add the types loaded from descriptor files
   std::vector<std::string> dynTypes;
   this->dataPtr->dynamicFactory->Types(dynTypes);
@@ -133,6 +151,7 @@ void MessageFactory::Types(std::vector<std::string> &_types)
 /////////////////////////////////////////////////
 void MessageFactory::LoadDescriptors(const std::string &_paths)
 {
+  std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
   this->dataPtr->dynamicFactory->LoadDescriptors(_paths);
 }
 

--- a/core/src/MessageFactory.cc
+++ b/core/src/MessageFactory.cc
@@ -105,7 +105,8 @@ MessageFactory::MessagePtr MessageFactory::New(
   }
 
   // Create a new message via FactoryFn
-  return factoryFn();
+  if (factoryFn) return factoryFn();
+  return nullptr;
 }
 
 /////////////////////////////////////////////////

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -31,6 +31,11 @@ if(TARGET INTEGRATION_Factory_TEST)
     "GZ_MSGS_TEST_PATH=\"${PROJECT_SOURCE_DIR}/test\"")
 endif()
 
+if(TARGET INTEGRATION_factory_concurrency)
+  target_compile_definitions(INTEGRATION_factory_concurrency PRIVATE
+    "GZ_MSGS_TEST_PATH=\"${PROJECT_SOURCE_DIR}/test\"")
+endif()
+
 if(TARGET INTEGRATION_gz_TEST)
     target_compile_definitions(INTEGRATION_gz_TEST PUBLIC
       "-DDETAIL_GZ_CONFIG_PATH=\"${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>\"")

--- a/test/integration/factory_concurrency.cc
+++ b/test/integration/factory_concurrency.cc
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "gz/msgs/Factory.hh"
+#include "gz/msgs/stringmsg.pb.h"
+
+static constexpr const char * kMsgsTestPath = GZ_MSGS_TEST_PATH;
+
+/////////////////////////////////////////////////
+/// \brief Exercise every public Factory entry point from multiple threads
+/// at once. MessageFactory documents that all member functions are thread
+/// safe; under ThreadSanitizer this test also acts as a data race detector.
+TEST(FactoryConcurrency, ParallelUse)
+{
+  const std::filesystem::path testPath(kMsgsTestPath);
+  const std::string descPath = (testPath / "desc" / "stringmsg.desc").string();
+
+  // Load the dynamic type up front so every creator thread can expect it.
+  gz::msgs::Factory::LoadDescriptors(descPath);
+  ASSERT_NE(nullptr, gz::msgs::Factory::New("example.msgs.StringMsg"));
+
+  // Static so that the lambdas below can read it without capturing it,
+  // which MSVC requires even for constants (C3493).
+  static constexpr int kIters = 10000;
+  std::atomic<int> failures{0};
+  std::vector<std::thread> threads;
+
+  // Creators of a generated (registered) type.
+  for (int t = 0; t < 4; ++t)
+  {
+    threads.emplace_back([&failures]
+    {
+      for (int i = 0; i < kIters; ++i)
+      {
+        if (!gz::msgs::Factory::New("gz.msgs.StringMsg"))
+          ++failures;
+      }
+    });
+  }
+
+  // Creators of a type known only through descriptors.
+  for (int t = 0; t < 2; ++t)
+  {
+    threads.emplace_back([&failures]
+    {
+      for (int i = 0; i < kIters / 10; ++i)
+      {
+        if (!gz::msgs::Factory::New("example.msgs.StringMsg"))
+          ++failures;
+      }
+    });
+  }
+
+  // Registration of new types while the creators run.
+  threads.emplace_back([]
+  {
+    for (int i = 0; i < kIters / 10; ++i)
+    {
+      gz::msgs::Factory::Register(
+          "test.factory_concurrency.Msg" + std::to_string(i),
+          [] { return std::make_unique<gz::msgs::StringMsg>(); });
+    }
+  });
+
+  // Type enumeration while the maps are being read and written.
+  threads.emplace_back([&failures]
+  {
+    for (int i = 0; i < kIters / 100; ++i)
+    {
+      std::vector<std::string> types;
+      gz::msgs::Factory::Types(types);
+      if (types.empty())
+        ++failures;
+    }
+  });
+
+  // Repeated descriptor loading of the same file.
+  threads.emplace_back([&descPath]
+  {
+    for (int i = 0; i < 20; ++i)
+    {
+      gz::msgs::Factory::LoadDescriptors(descPath);
+    }
+  });
+
+  for (auto &thread : threads)
+    thread.join();
+
+  EXPECT_EQ(0, failures);
+  EXPECT_NE(nullptr, gz::msgs::Factory::New("gz.msgs.StringMsg"));
+  EXPECT_NE(nullptr, gz::msgs::Factory::New("example.msgs.StringMsg"));
+  EXPECT_NE(nullptr, gz::msgs::Factory::New("test.factory_concurrency.Msg0"));
+}


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

`MessageFactory` is a singleton used concurrently (transport callback threads create messages while runtime loaded plugins register types), but none of its state was synchronized. The new `INTEGRATION_factory_concurrency` test fails without this fix, and ThreadSanitizer reports 12 data races.

Locking cannot be done by the callers: the factory is reached through a global singleton by libraries that do not know about each other (transport, simulation plugins, user code), so no caller can own a mutex that covers all users. The synchronization has to live inside the factory itself.

## Backport Policy
- [x] This **should not** be backported

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.