### PR TITLE
Construct the dynamic message factory lazily

### DIFF
--- a/core/src/DynamicFactory.cc
+++ b/core/src/DynamicFactory.cc
@@ -23,6 +23,7 @@
 #include <iterator>
 #include <string>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 #include "DynamicFactory.hh"
@@ -202,28 +203,28 @@ void DynamicFactory::Types(std::vector<std::string> &_types)
 DynamicFactory::MessagePtr DynamicFactory::New(const std::string &_msgType)
 {
   // Shortcut if the type has been already registered.
-  auto messageIt = dynamicMsgMap.find(_msgType);
-  if (messageIt != dynamicMsgMap.end())
-    return messageIt ->second();
+  auto messageIt = dynamicMsgMap.lower_bound(_msgType);
+  if (messageIt != dynamicMsgMap.end() && messageIt->first == _msgType)
+    return messageIt->second();
 
   // Nothing to do if we don't know about this type in the descriptor map.
   const auto *descriptor = pool.FindMessageTypeByName(_msgType);
   if (!static_cast<bool>(descriptor))
     return nullptr;
 
-  google::protobuf::Message *msgPtr(
-      dynamicMessageFactory.GetPrototype(descriptor)->New());
+  // The prototype is owned by dynamicMessageFactory, which outlives the
+  // lambda registered below.
+  const auto *prototype = dynamicMessageFactory.GetPrototype(descriptor);
 
   // Create the lambda for registration purposes.
-  auto f = [msgPtr]() -> MessagePtr
+  auto f = [prototype]() -> MessagePtr
   {
-    MessagePtr ptr(msgPtr->New());
-    return ptr;
+    return MessagePtr(prototype->New());
   };
 
-  // Register the new type for the future.
-  dynamicMsgMap[_msgType] = f;
+  // Register the new type for the future, reusing the lookup position.
+  messageIt = dynamicMsgMap.emplace_hint(messageIt, _msgType, std::move(f));
 
-  return f();
+  return messageIt->second();
 }
 }  // namespace gz::msgs

--- a/core/src/DynamicFactory.cc
+++ b/core/src/DynamicFactory.cc
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <iterator>
 #include <string>
+#include <system_error>
 #include <vector>
 
 #include "DynamicFactory.hh"
@@ -101,6 +102,15 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
         descFile.rfind(".proto.bin") == std::string::npos)
       return;
 
+    // Skip files that were already loaded, keyed on the canonical path so
+    // that the same file reached via multiple search paths (e.g.
+    // GZ_DESCRIPTOR_PATH and the global share directory) is parsed once.
+    std::error_code pathErr;
+    auto canonicalPath = std::filesystem::weakly_canonical(descFile, pathErr);
+    const std::string pathKey = pathErr ? descFile : canonicalPath.string();
+    if (this->loadedDescFiles.find(pathKey) != this->loadedDescFiles.end())
+      return;
+
     // Parse the .desc file.
     std::ifstream ifs(descFile);
     if (!ifs.is_open())
@@ -117,6 +127,10 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
                 << descFile << "]" << std::endl;
       return;
     }
+
+    // Record the file only after a successful parse so that transient
+    // failures above remain retryable.
+    this->loadedDescFiles.insert(pathKey);
 
     // Place the real descriptors in the descriptor pool.
     for (const google::protobuf::FileDescriptorProto &fileDescriptorProto :

--- a/core/src/DynamicFactory.cc
+++ b/core/src/DynamicFactory.cc
@@ -129,11 +129,8 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
       return;
     }
 
-    // Record the file only after a successful parse so that transient
-    // failures above remain retryable.
-    this->loadedDescFiles.insert(pathKey);
-
     // Place the real descriptors in the descriptor pool.
+    bool allBuilt = true;
     for (const google::protobuf::FileDescriptorProto &fileDescriptorProto :
          fileDescriptorSet.file())
     {
@@ -146,6 +143,7 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
 
       if (!static_cast<bool>(this->pool.BuildFile(fileDescriptorProto)))
       {
+        allBuilt = false;
         std::cerr << "DynamicFactory(). Unable to place descriptors from ["
                   << descFile << "] in the descriptor pool" << std::endl;
       }
@@ -154,6 +152,13 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
         this->db.Add(fileDescriptorProto);
       }
     }
+
+    // Record the file only once every descriptor in it reached the pool,
+    // so that failures above remain retryable. In particular a file whose
+    // imports live in another descriptor file that has not been loaded yet
+    // must still be reloadable once that dependency is available.
+    if (allBuilt)
+      this->loadedDescFiles.insert(pathKey);
   };
 
   const std::string ownDescFile = GZ_MSGS_DESC_FILENAME;

--- a/core/src/DynamicFactory.cc
+++ b/core/src/DynamicFactory.cc
@@ -112,8 +112,9 @@ void DynamicFactory::LoadDescriptors(const std::string &_paths)
     if (this->loadedDescFiles.find(pathKey) != this->loadedDescFiles.end())
       return;
 
-    // Parse the .desc file.
-    std::ifstream ifs(descFile);
+    // Parse the .desc file. Binary mode matters on Windows, where a text
+    // mode stream would stop reading at the first 0x1A byte.
+    std::ifstream ifs(descFile, std::ios::binary);
     if (!ifs.is_open())
     {
       std::cerr << "DynamicFactory(): Unable to open [" << descFile << "]"

--- a/core/src/DynamicFactory.hh
+++ b/core/src/DynamicFactory.hh
@@ -25,6 +25,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 
@@ -76,6 +77,10 @@ class DynamicFactory
   /// std::unique_ptr to a new empty instance of the message or nullptr if
   /// the message is not registered.
   private: std::map<std::string, FactoryFn> dynamicMsgMap;
+
+  /// \brief Canonical paths of the descriptor files already loaded, used
+  /// to avoid parsing the same file reached via multiple search paths.
+  private: std::unordered_set<std::string> loadedDescFiles;
 
   /// \brief We store the descriptors here.
   private: google::protobuf::DescriptorPool pool;

--- a/core/src/MessageFactory.cc
+++ b/core/src/MessageFactory.cc
@@ -40,9 +40,24 @@ class MessageFactory::Implementation
   public: FactoryFnCollection msgMap;
 
   /// \brief Factory for messages built at runtime from loaded descriptors.
-  public: std::unique_ptr<gz::msgs::DynamicFactory> dynamicFactory =
-      std::make_unique<gz::msgs::DynamicFactory>();
+  public: std::unique_ptr<gz::msgs::DynamicFactory> dynamicFactory;
+
+  /// \brief Get the dynamic factory, constructing it on first use.
+  /// Construction scans and parses every descriptor file reachable from
+  /// the GZ_DESCRIPTOR_PATH environment variable and the install share
+  /// directory, so it is deferred until a dynamic lookup needs it.
+  /// The caller must hold mutex.
+  /// \return Reference to the dynamic factory.
+  public: gz::msgs::DynamicFactory &EnsureDynamicFactory();
 };
+
+/////////////////////////////////////////////////
+gz::msgs::DynamicFactory &MessageFactory::Implementation::EnsureDynamicFactory()
+{
+  if (!this->dynamicFactory)
+    this->dynamicFactory = std::make_unique<gz::msgs::DynamicFactory>();
+  return *this->dynamicFactory;
+}
 
 /////////////////////////////////////////////////
 MessageFactory::MessageFactory():
@@ -100,7 +115,7 @@ MessageFactory::MessagePtr MessageFactory::New(
     else
     {
       // Create a new message via dynamic descriptors
-      return this->dataPtr->dynamicFactory->New(type);
+      return this->dataPtr->EnsureDynamicFactory().New(type);
     }
   }
 
@@ -135,7 +150,7 @@ void MessageFactory::Types(std::vector<std::string> &_types)
 
   // Add the types loaded from descriptor files
   std::vector<std::string> dynTypes;
-  this->dataPtr->dynamicFactory->Types(dynTypes);
+  this->dataPtr->EnsureDynamicFactory().Types(dynTypes);
 
   // Use set to remove duplicates
   std::unordered_set<std::string> typesSet(dynTypes.begin(), dynTypes.end());
@@ -154,7 +169,7 @@ void MessageFactory::Types(std::vector<std::string> &_types)
 void MessageFactory::LoadDescriptors(const std::string &_paths)
 {
   std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
-  this->dataPtr->dynamicFactory->LoadDescriptors(_paths);
+  this->dataPtr->EnsureDynamicFactory().LoadDescriptors(_paths);
 }
 
 }  // namespace gz::msgs

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -36,6 +36,11 @@ if(TARGET INTEGRATION_factory_concurrency)
     "GZ_MSGS_TEST_PATH=\"${PROJECT_SOURCE_DIR}/test\"")
 endif()
 
+if(TARGET INTEGRATION_factory_lazy)
+  target_compile_definitions(INTEGRATION_factory_lazy PRIVATE
+    "GZ_MSGS_TEST_PATH=\"${PROJECT_SOURCE_DIR}/test\"")
+endif()
+
 if(TARGET INTEGRATION_gz_TEST)
     target_compile_definitions(INTEGRATION_gz_TEST PUBLIC
       "-DDETAIL_GZ_CONFIG_PATH=\"${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>\"")

--- a/test/integration/factory_descriptor_retry.cc
+++ b/test/integration/factory_descriptor_retry.cc
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <google/protobuf/descriptor.pb.h>
+
+#include <filesystem>
+#include <fstream>
+
+#include "gz/msgs/MessageFactory.hh"
+
+namespace {
+
+//////////////////////////////////////////////////
+/// \brief Serialize a descriptor set holding a single file to _path.
+void WriteDescriptorSet(const std::filesystem::path &_path,
+                        const google::protobuf::FileDescriptorProto &_file)
+{
+  google::protobuf::FileDescriptorSet fileSet;
+  *fileSet.add_file() = _file;
+  std::ofstream ofs(_path, std::ios::binary);
+  ASSERT_TRUE(fileSet.SerializeToOstream(&ofs));
+}
+}  // namespace
+
+/////////////////////////////////////////////////
+/// \brief A descriptor file whose import could not be resolved must remain
+/// retryable: once the descriptor file providing the missing dependency has
+/// been loaded, reloading the first file must succeed. This guards the
+/// descriptor file dedup logic, which must not record a file whose
+/// descriptors did not all reach the pool.
+TEST(FactoryDescriptorRetryTest, ReloadAfterMissingImport)
+{
+  const auto dir = std::filesystem::path(::testing::TempDir()) /
+      "gz_msgs_factory_descriptor_retry";
+  std::filesystem::create_directories(dir);
+
+  // b.proto: package b.msgs; message Bar { int32 x = 1; }
+  google::protobuf::FileDescriptorProto bFile;
+  bFile.set_name("b.proto");
+  bFile.set_package("b.msgs");
+  bFile.set_syntax("proto3");
+  auto *bar = bFile.add_message_type();
+  bar->set_name("Bar");
+  auto *x = bar->add_field();
+  x->set_name("x");
+  x->set_number(1);
+  x->set_type(google::protobuf::FieldDescriptorProto::TYPE_INT32);
+  x->set_label(google::protobuf::FieldDescriptorProto::LABEL_OPTIONAL);
+
+  // a.proto: package a.msgs; import "b.proto";
+  // message Foo { b.msgs.Bar bar = 1; }
+  google::protobuf::FileDescriptorProto aFile;
+  aFile.set_name("a.proto");
+  aFile.set_package("a.msgs");
+  aFile.set_syntax("proto3");
+  aFile.add_dependency("b.proto");
+  auto *foo = aFile.add_message_type();
+  foo->set_name("Foo");
+  auto *barField = foo->add_field();
+  barField->set_name("bar");
+  barField->set_number(1);
+  barField->set_type(google::protobuf::FieldDescriptorProto::TYPE_MESSAGE);
+  barField->set_type_name(".b.msgs.Bar");
+  barField->set_label(google::protobuf::FieldDescriptorProto::LABEL_OPTIONAL);
+
+  const auto aPath = dir / "a.desc";
+  const auto bPath = dir / "b.desc";
+  WriteDescriptorSet(aPath, aFile);
+  WriteDescriptorSet(bPath, bFile);
+
+  gz::msgs::MessageFactory factory;
+
+  // Loading a.desc fails: its import lives in b.desc, which is unknown yet.
+  factory.LoadDescriptors(aPath.string());
+  EXPECT_EQ(nullptr, factory.New("a.msgs.Foo"));
+
+  // Load the missing dependency.
+  factory.LoadDescriptors(bPath.string());
+  ASSERT_NE(nullptr, factory.New("b.msgs.Bar"));
+
+  // Reloading a.desc must now succeed instead of being skipped as a
+  // duplicate.
+  factory.LoadDescriptors(aPath.string());
+  EXPECT_NE(nullptr, factory.New("a.msgs.Foo"));
+}

--- a/test/integration/factory_lazy.cc
+++ b/test/integration/factory_lazy.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include <gz/utils/Environment.hh>
+
+#include "gz/msgs/Factory.hh"
+
+static constexpr const char * kMsgsTestPath = GZ_MSGS_TEST_PATH;
+
+/////////////////////////////////////////////////
+/// \brief The dynamic factory is constructed on first dynamic use, so
+/// GZ_DESCRIPTOR_PATH is read at that point rather than at library load.
+/// This test fails if descriptors are loaded eagerly at load time (the
+/// environment variable is not set yet at that point) or if creating a
+/// generated type wrongly triggers descriptor loading (it runs before the
+/// variable is set below).
+TEST(FactoryLazyTest, DescriptorPathReadAtFirstDynamicUse)
+{
+  // Creating a generated type must not construct the dynamic factory.
+  EXPECT_NE(nullptr, gz::msgs::Factory::New("gz.msgs.StringMsg"));
+
+  // Point GZ_DESCRIPTOR_PATH at the test descriptors only now, after the
+  // process started and after a generated type was created.
+  const std::filesystem::path testPath(kMsgsTestPath);
+  ASSERT_TRUE(gz::utils::setenv(
+      "GZ_DESCRIPTOR_PATH", (testPath / "desc").string()));
+
+  // The first dynamic lookup reads the environment set above.
+  EXPECT_NE(nullptr, gz::msgs::Factory::New("example.msgs.StringMsg"));
+}


### PR DESCRIPTION
# 🎉 New feature

## Summary

Constructing the message factory currently scans and parses every descriptor file reachable from `GZ_DESCRIPTOR_PATH` and the install share directory at library load. Every process linking gz-msgs pays for it, even if it never uses a dynamic message type.

This PR constructs the dynamic factory at the first dynamic lookup instead. Process startup drops from ~5 ms to ~2 ms in a micro benchmark; cost per message is unchanged. It also deduplicates descriptor files reachable through several search paths and fixes a prototype leak in `DynamicFactory::New`. One behavior change: `GZ_DESCRIPTOR_PATH` is now read at first dynamic use, pinned by the new `INTEGRATION_factory_lazy` test, which fails against the eager implementation.

Built on top of #610.

## Backport Policy
- [x] Other (fill in yourself)

Planned as manual backports: this branch depends on the pimpl from #610 and cannot be cherry picked. An ABI safe variant is prepared separately for stable branches.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
