### PR TITLE
Add entity_namesapce to EntityFactory

### DIFF
--- a/proto/gz/msgs/entity_factory.proto
+++ b/proto/gz/msgs/entity_factory.proto
@@ -83,4 +83,7 @@ message EntityFactory
   /// * `pose.orientation` is used in conjunction with heading:
   ///       Quaternion::fromEuler(0, 0, heading) * pose.orientation
   SphericalCoordinates spherical_coordinates = 11;
+
+  /// \brief Optional new namespace for the entity, overrides the namespace in the SDF.
+  string entity_namespace              = 12;
 }


### PR DESCRIPTION
# 🎉 New feature

Related to #595

## Summary
This PR adds an optional entity_namespace field to the existing EntityFactory message to support spawning entities with a specified namespace.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)
## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)