### PR TITLE
Deprecate EntityFactoryWithNs and EntityFactoryWithNs_V

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -8,6 +8,14 @@ release will remove the deprecated code.
 
 ## Gazebo Msgs 12.X to 13.X
 
+### Deprecations
+
+1. **entity_factory_with_ns.proto**
+    + This message is deprecated. Use `EntityFactory` instead.
+
+1. **entity_factory_with_ns_v.proto**
+    + This message is deprecated. Use `EntityFactory_V` instead.
+
 
 ## Gazebo Msgs 11.X to 12.X
 

--- a/proto/gz/msgs/entity_factory_with_ns.proto
+++ b/proto/gz/msgs/entity_factory_with_ns.proto
@@ -29,6 +29,8 @@ option java_outer_classname = "EntityFactoryWithNsProtos";
 /// 2. From an SDF file (sdf_filename)
 /// 3. From a message (model / light)
 /// 4. Cloning an existing entity (clone_name)
+/// This message will be deprecated, use EntityFactory instead.
+/// Remove this message in gz-msgs14.
 
 import "gz/msgs/header.proto";
 import "gz/msgs/light.proto";
@@ -38,6 +40,9 @@ import "gz/msgs/spherical_coordinates.proto";
 
 message EntityFactoryWithNs
 {
+  /// \brief Deprecated message.
+  option deprecated = true;
+
   /// \brief Optional header data
   Header header                    = 1;
 

--- a/proto/gz/msgs/entity_factory_with_ns.proto
+++ b/proto/gz/msgs/entity_factory_with_ns.proto
@@ -29,7 +29,7 @@ option java_outer_classname = "EntityFactoryWithNsProtos";
 /// 2. From an SDF file (sdf_filename)
 /// 3. From a message (model / light)
 /// 4. Cloning an existing entity (clone_name)
-/// This message will be deprecated, use EntityFactory instead.
+/// This message is deprecated, use EntityFactory instead.
 /// Remove this message in gz-msgs14.
 
 import "gz/msgs/header.proto";

--- a/proto/gz/msgs/entity_factory_with_ns_v.proto
+++ b/proto/gz/msgs/entity_factory_with_ns_v.proto
@@ -26,7 +26,7 @@ option java_outer_classname = "EntityFactoryWithNsVProtos";
 //
 import "gz/msgs/entity_factory_with_ns.proto";
 import "gz/msgs/header.proto";
-/// This message will be deprecated, use EntityFactory_V instead.
+/// This message is deprecated, use EntityFactory_V instead.
 /// Remove this message in gz-msgs14.
 
 message EntityFactoryWithNs_V

--- a/proto/gz/msgs/entity_factory_with_ns_v.proto
+++ b/proto/gz/msgs/entity_factory_with_ns_v.proto
@@ -26,9 +26,14 @@ option java_outer_classname = "EntityFactoryWithNsVProtos";
 //
 import "gz/msgs/entity_factory_with_ns.proto";
 import "gz/msgs/header.proto";
+/// This message will be deprecated, use EntityFactory_V instead.
+/// Remove this message in gz-msgs14.
 
 message EntityFactoryWithNs_V
 {
+  /// \brief Deprecated message.
+  option deprecated = true;
+
   /// \brief Optional header data
   Header header = 1;
 


### PR DESCRIPTION
Related to #595 

## Summary
Deprecate `EntityFactoryWithNs` and `EntityFactoryWithNs_V`.
Use `EntityFactory` and `EntityFactory_V` instead. The migration guide was updated with this change.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)