### PR TITLE
Open descriptor files in binary mode so Windows reads them fully (backport #611)

### DIFF
--- a/src/Factory.cc
+++ b/src/Factory.cc
@@ -109,8 +109,9 @@ class DynamicFactory
         if ((*dirIter).rfind(".desc") == std::string::npos)
           continue;
 
-        // Parse the .desc file.
-        std::ifstream ifs(*dirIter);
+        // Parse the .desc file. Binary mode matters on Windows, where a
+        // text mode stream would stop reading at the first 0x1A byte.
+        std::ifstream ifs(*dirIter, std::ios::binary);
         if (!ifs.is_open())
         {
           std::cerr << "DynamicFactory(): Unable to open [" << *dirIter << "]"


### PR DESCRIPTION
This is a manual backport of pull request #611.

Manual adaptations:
* Only the fix that opens descriptor files in binary mode applies to this branch. The descriptor loading code here has a single descriptor source and does not scan the install share path, so the lazy construction and the dedup changes do not apply.
* The change lives in src/Factory.cc because this branch predates the split into MessageFactory and DynamicFactory.
